### PR TITLE
Test cvd

### DIFF
--- a/pyrate/covariance.py
+++ b/pyrate/covariance.py
@@ -74,16 +74,28 @@ def cvd(ifg_path, params, r_dist, calc_alpha=False,
     Calculate the 1D covariance function of an entire interferogram as the
     radial average of its 2D autocorrelation.
 
-    :param ifg_path: An interferogram.
+    Parameters
+    ----------
+    ifg_path : An interferogram.
         ifg: :py:class:`pyrate.shared.Ifg`.
-    :param params: dict
+    params : dict
         dictionary of configuration parameters
-    :param calc_alpha: bool
+    r_dist : ndarray
+        array of distance from the centre of the interferogram. See Rdist 
+        class for more details
+    calc_alpha : bool
         calculate alpha, the exponential length-scale of decay factor.
-    :param write_vals: bool
+    write_vals : bool
         write maxvar and alpha values to interferogram metadata.
-    :param save_acg: bool
+    save_acg : bool
         write acg and radial distance data to numpy array
+    
+    Returns
+    -------
+    maxvar : ndarray
+        array of shape (nifgs, 1)
+    alpha : ndarray
+        array of shape (nifgs, 1)
     """
 
     if isinstance(ifg_path, str):  # used during MPI
@@ -101,7 +113,7 @@ def cvd(ifg_path, params, r_dist, calc_alpha=False,
         phase = ifg.phase_data
 
     maxvar, alpha = cvd_from_phase(phase, ifg, r_dist, calc_alpha,
-                                   save_acg=save_acg)
+                                   save_acg=save_acg, params=params)
 
     if write_vals:
         _add_metadata(ifg, maxvar, alpha)
@@ -115,8 +127,8 @@ def cvd(ifg_path, params, r_dist, calc_alpha=False,
 def _add_metadata(ifg, maxvar, alpha):
     """convenience function for saving metadata to ifg"""
     md = ifg.meta_data
-    md[ifc.PYRATE_MAXVAR] = str(maxvar) #.astype('str')
-    md[ifc.PYRATE_ALPHA] = str(alpha) #.astype('str')
+    md[ifc.PYRATE_MAXVAR] = str(maxvar)
+    md[ifc.PYRATE_ALPHA] = str(alpha)
     ifg.write_modified_phase()
 
 
@@ -135,19 +147,24 @@ def cvd_from_phase(phase, ifg, r_dist, calc_alpha, save_acg=False,
     and a ifg class
     Parameters
     ----------
-    phase: ndarray
+    phase : ndarray
         phase data corresping to the ifg
-    ifg: shared.Ifg class instance
-    calc_alpha: bool, optional
+    ifg : shared.Ifg class instance
+    r_dist : ndarray
+        array of distance from the centre of the interferogram. See Rdist 
+        class for more details
+    calc_alpha : bool, optional
         whether alpha is required
-    save_acg: bool, optional
+    save_acg : bool, optional
         write acg and radial distance data to numpy array
+    params : dict, optional
+        dictionary of config parameters. Must be provided if save_acg=True
 
     Return
     ------
-    maxvar: float
+    maxvar : float
         maxvar
-    alpha:
+    alpha :
         alpha
     """
     # pylint: disable=invalid-name

--- a/pyrate/covariance.py
+++ b/pyrate/covariance.py
@@ -262,12 +262,22 @@ class RDist:
 
 
 def _get_autogrid(phase):
-    fft_phase = fft2(phase)
-    pspec = real(fft_phase) ** 2 + imag(fft_phase) ** 2
-    autocorr_grid = ifft2(pspec)
+    autocorr_grid = _calc_autoc_grid(phase)
     nzc = np.sum(np.sum(phase != 0))
     autocorr_grid = fftshift(real(autocorr_grid)) / nzc
     return autocorr_grid
+
+
+def _calc_autoc_grid(phase):
+    pspec = _calc_power_spectrum(phase)
+    autocorr_grid = ifft2(pspec)
+    return autocorr_grid.astype(np.float32)
+
+
+def _calc_power_spectrum(phase):
+    fft_phase = fft2(phase)
+    pspec = real(fft_phase) ** 2 + imag(fft_phase) ** 2
+    return pspec.astype(dtype=np.float32)
 
 
 def get_vcmt(ifgs, maxvar):

--- a/pyrate/covariance.py
+++ b/pyrate/covariance.py
@@ -201,7 +201,8 @@ def cvd_from_phase(phase, ifg, r_dist, calc_alpha, save_acg=False,
 
     # optionally save acg vs dist observations to disk
     if save_acg:
-        _save_cvd_data(acg, r_dist, ifg.data_path, params[cf.TMPDIR])
+        _save_cvd_data(acg, r_dist[indices_to_keep],
+                       ifg.data_path, params[cf.TMPDIR])
 
     if calc_alpha:
         # bin width for collecting data

--- a/pyrate/covariance.py
+++ b/pyrate/covariance.py
@@ -271,7 +271,7 @@ def _get_autogrid(phase):
 def _calc_autoc_grid(phase):
     pspec = _calc_power_spectrum(phase)
     autocorr_grid = ifft2(pspec)
-    return autocorr_grid.astype(np.float32)
+    return autocorr_grid.astype(dtype=np.complex64)
 
 
 def _calc_power_spectrum(phase):

--- a/pyrate/scripts/run_pyrate.py
+++ b/pyrate/scripts/run_pyrate.py
@@ -482,7 +482,7 @@ def process_ifgs(ifg_paths, params, rows, cols):
     ref_phase_estimation(ifg_paths, params, refpx, refpy)
 
     # spatio-temporal aps filter
-    # wrap_spatio_temporal_filter(ifg_paths, params, tiles, preread_ifgs)
+    wrap_spatio_temporal_filter(ifg_paths, params, tiles, preread_ifgs)
 
     maxvar, vcmt = maxvar_vcm_calc(ifg_paths, params, preread_ifgs)
 
@@ -567,7 +567,7 @@ def maxvar_vcm_calc(ifg_paths, params, preread_ifgs):
         log.info('Calculating maxvar for {} of process ifgs {} of '
                  'total {}'.format(n+1, len(prcs_ifgs), len(ifg_paths)))
         process_maxvar.append(vcm_module.cvd(i, params, r_dist,
-                                             calc_alpha=False,
+                                             calc_alpha=True,
                                              write_vals=True,
                                              save_acg=True)[0])
     if mpiops.rank == MASTER_PROCESS:

--- a/pyrate/scripts/run_pyrate.py
+++ b/pyrate/scripts/run_pyrate.py
@@ -482,7 +482,7 @@ def process_ifgs(ifg_paths, params, rows, cols):
     ref_phase_estimation(ifg_paths, params, refpx, refpy)
 
     # spatio-temporal aps filter
-    wrap_spatio_temporal_filter(ifg_paths, params, tiles, preread_ifgs)
+    # wrap_spatio_temporal_filter(ifg_paths, params, tiles, preread_ifgs)
 
     maxvar, vcmt = maxvar_vcm_calc(ifg_paths, params, preread_ifgs)
 
@@ -566,7 +566,10 @@ def maxvar_vcm_calc(ifg_paths, params, preread_ifgs):
     for n, i in enumerate(prcs_ifgs):
         log.info('Calculating maxvar for {} of process ifgs {} of '
                  'total {}'.format(n+1, len(prcs_ifgs), len(ifg_paths)))
-        process_maxvar.append(vcm_module.cvd(i, params, r_dist)[0])
+        process_maxvar.append(vcm_module.cvd(i, params, r_dist,
+                                             calc_alpha=False,
+                                             write_vals=True,
+                                             save_acg=True)[0])
     if mpiops.rank == MASTER_PROCESS:
         maxvar = np.empty(len(ifg_paths), dtype=np.float64)
         maxvar[process_indices] = process_maxvar


### PR DESCRIPTION
New tests added for 

1. covariance._add_metadata
2. covariance._save_cvd_data

And bug fix in the current develop branch - we were sending different length vectors to `_save_cvd_data` and it was not being picked up as we did not have tests, and these functions were not being called by the main `run_pyrate` script.

These functions were not being tested before this PR and should also increate test coverage.

Also more refactoring of the fft code during cvd computation to reduce memory usage.