### PR TITLE
Update mst to work with networkx v2.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ PyYAML==5.1.1
 netCDF4==1.5.1.2
 matplotlib==3.1.1
 pyproj==1.9.5.1
-networkx==1.11
+networkx==2.3
 Pillow==6.1.0
 luigi==1.3.0
 joblib==0.13.2

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'GDAL==' + GDAL_VERSION,
         'matplotlib==3.1.1',
         'pyproj==1.9.5.1',
-        'networkx==1.11',
+        'networkx==2.3',
         'Pillow==6.1.0',
         'luigi==1.3.0',
         'joblib==0.13.2',


### PR DESCRIPTION
Issue was that .edges() (and nodes etc) have changed from returning list/dict copies to nx's own View objects. There was a guard checking if the mst edges was a list instance before iterating over them. Changing this guard to check if it's an instance of EdgeView fixes the problem.

The difference is that these View objects now return dynamic views of the edges/nodes that change as the graph/tree changes. More details [here](https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html).