### PR TITLE
Limit travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+branches:
+  only:
+  - develop
+  - /^release-.*$/
+  - master
+
 language: python
 
 python: 3.6


### PR DESCRIPTION
This will only trigger travis to run on develop, master and release- (assuming we'll use the "release" prefix for dev -> master staging branches). This can be changed in .travis.yml.