### PR TITLE
Upgrade mpi4py 2.0.0 -> 3.0.2

### DIFF
--- a/pyrate/mpiops.py
+++ b/pyrate/mpiops.py
@@ -25,8 +25,8 @@ import numpy as np
 
 log = logging.getLogger(__name__)
 # We're having trouble with the MPI pickling and 64bit integers
-MPI.pickle.dumps = pickle.dumps
-MPI.pickle.loads = pickle.loads
+# MPI.pickle.dumps = pickle.dumps
+# MPI.pickle.loads = pickle.loads
 
 # module-level MPI 'world' object representing all connected nodes
 comm = MPI.COMM_WORLD

--- a/pyrate/mpiops.py
+++ b/pyrate/mpiops.py
@@ -25,8 +25,7 @@ import numpy as np
 
 log = logging.getLogger(__name__)
 # We're having trouble with the MPI pickling and 64bit integers
-# MPI.pickle.dumps = pickle.dumps
-# MPI.pickle.loads = pickle.loads
+MPI.pickle.__init__(pickle.dumps, pickle.loads)
 
 # module-level MPI 'world' object representing all connected nodes
 comm = MPI.COMM_WORLD

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 Click==7.0
 numpy==1.16.4
 Cython==0.29.11
-mpi4py==2.0.0
+mpi4py==3.0.2
 scipy==1.3.0
 PyYAML==5.1.1
 netCDF4==1.5.1.2

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'Click==7.0',
         'numpy==1.16.4',
         'Cython==0.29.11',
-        'mpi4py==2.0.0',
+        'mpi4py==3.0.2',
         'scipy==1.3.0',
         'PyYAML==5.1.1',
         'netCDF4==1.5.1.2',


### PR DESCRIPTION
Update to the latest version of mpi4py. This is operating in conjunction with openmpi 2.1.1. Workflow carries out successfully on Raijin but unit tests are still an issue (#190 ).