### PR TITLE
Turn down parallel job logging messages

### DIFF
--- a/pyrate/__init__.py
+++ b/pyrate/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pkg_resources
+import os
 
 """
 PyRate
@@ -8,3 +9,6 @@ PyRate
 Main package for PyRate.
 """
 __version__ = pkg_resources.require("Py-Rate")[0].version
+
+# Turn off MPI warning
+os.environ['OMPI_MCA_btl_base_warn_component_unused'] = '0'

--- a/pyrate/config.py
+++ b/pyrate/config.py
@@ -33,6 +33,7 @@ from pyrate import mpiops
 
 # general constants
 NO_MULTILOOKING = 1
+LOG_LEVEL = 'INFO'
 
 # constants for lookups
 #: STR; Name of input interferogram list file

--- a/pyrate/linrate.py
+++ b/pyrate/linrate.py
@@ -22,11 +22,14 @@ method.
 # pylint: disable= too-many-locals
 # pylint: disable= too-many-arguments
 import itertools
+
 from scipy.linalg import solve, cholesky, qr, inv
 from numpy import nan, isnan, sqrt, diag, delete, array, float32
 import numpy as np
 from joblib import Parallel, delayed
+
 from pyrate import config as cf
+from pyrate.shared import joblib_log_level
 
 
 def linear_rate(ifgs, params, vcmt, mst=None):
@@ -53,7 +56,8 @@ def linear_rate(ifgs, params, vcmt, mst=None):
     # nested loops to loop over the 2 image dimensions
     if parallel == 1:
 
-        res = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        res = Parallel(n_jobs=params[cf.PROCESSES], 
+                       verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_linear_rate_by_rows)(r, cols, mst, nsig, obs,
                                           pthresh, span, vcmt)
             for r in range(rows))
@@ -63,7 +67,8 @@ def linear_rate(ifgs, params, vcmt, mst=None):
         error = res[:, :, 1]
         samples = res[:, :, 2]
     elif parallel == 2:
-        res = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        res = Parallel(n_jobs=params[cf.PROCESSES], 
+                       verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_linear_rate_by_pixel)(r, c, mst, nsig, obs,
                                            pthresh, span, vcmt)
             for r, c in itertools.product(range(rows), range(cols)))

--- a/pyrate/mst.py
+++ b/pyrate/mst.py
@@ -30,7 +30,7 @@ from joblib import Parallel, delayed
 from pyrate.algorithm import ifg_date_lookup
 from pyrate.algorithm import ifg_date_index_lookup
 from pyrate import config as cf
-from pyrate.shared import IfgPart, create_tiles
+from pyrate.shared import IfgPart, create_tiles, joblib_log_level
 np.seterr(invalid='ignore')  # stops RuntimeWarning in nan conversion
 
 # TODO: may need to implement memory saving row-by-row access
@@ -96,7 +96,8 @@ def mst_parallel(ifgs, params):
     if params[cf.PARALLEL]:
         log.info('Calculating MST using {} tiles in parallel using {} ' \
                  'processes'.format(no_tiles, ncpus))
-        t_msts = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        t_msts = Parallel(n_jobs=params[cf.PROCESSES], 
+                          verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(mst_multiprocessing)(t, ifg_paths)
             for t in tiles)
         for k, tile in enumerate(tiles):

--- a/pyrate/orbital.py
+++ b/pyrate/orbital.py
@@ -28,7 +28,7 @@ from scipy.linalg import lstsq
 
 from pyrate.algorithm import master_slave_ids, get_all_epochs
 from pyrate import mst, shared, prepifg
-from pyrate.shared import nanmedian, Ifg
+from pyrate.shared import nanmedian, Ifg, joblib_log_level
 from pyrate import config as cf
 from pyrate import ifgconstants as ifc
 
@@ -141,7 +141,8 @@ def _orbital_correction(ifgs_or_ifg_paths, params, mlooked=None, offset=True,
     elif method == INDEPENDENT_METHOD:
         # not running in parallel
         # raises swig object pickle error
-        # Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        # Parallel(n_jobs=params[cf.PROCESSES], 
+        #          verbose=joblib_log_level(cf.LOG_LEVEL))(
         #     delayed(_independent_correction)(ifg, degree, offset, params)
         #     for ifg in ifgs)
         for ifg in ifgs_or_ifg_paths:

--- a/pyrate/ref_phs_est.py
+++ b/pyrate/ref_phs_est.py
@@ -18,10 +18,12 @@
 This Python module implements a reference phase estimation algorithm.
 """
 import logging
+
 import numpy as np
 from joblib import Parallel, delayed
+
 from pyrate import config as cf
-from pyrate.shared import nanmedian
+from pyrate.shared import nanmedian, joblib_log_level
 from pyrate import ifgconstants as ifc
 
 log = logging.getLogger(__name__)
@@ -76,7 +78,8 @@ def est_ref_phase_method2(ifgs, params, refpx, refpy):
     thresh = chipsize * chipsize * params[cf.REF_MIN_FRAC]
     phase_data = [i.phase_data for i in ifgs]
     if params[cf.PARALLEL]:
-        ref_phs = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        ref_phs = Parallel(n_jobs=params[cf.PROCESSES],
+                           verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_est_ref_phs_method2)(p, half_chip_size,
                                           refpx, refpy, thresh)
             for p in phase_data)
@@ -131,7 +134,8 @@ def est_ref_phase_method1(ifgs, params):
     comp = np.ravel(comp, order='F')
     if params[cf.PARALLEL]:
         log.info("Calculating ref phase using multiprocessing")
-        ref_phs = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        ref_phs = Parallel(n_jobs=params[cf.PROCESSES], 
+                           verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_est_ref_phs_method1)(p, comp)
             for p in phase_data)
         for n, ifg in enumerate(ifgs):

--- a/pyrate/refpixel.py
+++ b/pyrate/refpixel.py
@@ -21,12 +21,13 @@ import os
 from os.path import join
 import logging
 from itertools import product
+
 import numpy as np
 from numpy import isnan, std, mean, sum as nsum
 from joblib import Parallel, delayed
 
 import pyrate.config as cf
-from pyrate.shared import Ifg
+from pyrate.shared import Ifg, joblib_log_level
 
 log = logging.getLogger(__name__)
 
@@ -53,7 +54,8 @@ def ref_pixel(ifgs, params):
     parallel = params[cf.PARALLEL]
     if parallel:
         phase_data = [i.phase_data for i in ifgs]
-        mean_sds = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        mean_sds = Parallel(n_jobs=params[cf.PROCESSES], 
+                            verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_ref_pixel_multi)(g, half_patch_size, phase_data,
                                      thresh, params) for g in grid)
         refy, refx = find_min_mean(mean_sds, grid)

--- a/pyrate/scripts/converttogtif.py
+++ b/pyrate/scripts/converttogtif.py
@@ -96,7 +96,8 @@ def do_geotiff(base_unw_paths, params):
     if parallel:
         log.info("Running geotiff conversion in parallel with {} "
                  "processes".format(params[cf.PROCESSES]))
-        dest_base_ifgs = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        dest_base_ifgs = Parallel(n_jobs=params[cf.PROCESSES], 
+                         verbose=shared.joblib_log_level(cf.LOG_LEVEL))(
             delayed(_geotiff_multiprocessing)(p, params)
             for p in base_unw_paths)
     else:

--- a/pyrate/scripts/main.py
+++ b/pyrate/scripts/main.py
@@ -45,6 +45,7 @@ def cli(verbosity):
     more details.
     """
     pylog.configure(verbosity)
+    cf.LOG_LEVEL = verbosity
 
 
 @cli.command()

--- a/pyrate/scripts/run_prepifg.py
+++ b/pyrate/scripts/run_prepifg.py
@@ -23,9 +23,11 @@ import logging
 import os
 from os.path import join
 import re
+
 import glob2
 from joblib import Parallel, delayed
 import numpy as np
+
 from pyrate import prepifg
 from pyrate import config as cf
 from pyrate import shared
@@ -105,7 +107,8 @@ def do_prepifg(gtiff_paths, params):
                                            user_exts=user_exts)
         thresh = params[cf.NO_DATA_AVERAGING_THRESHOLD]
         if parallel:
-            Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+            Parallel(n_jobs=params[cf.PROCESSES], 
+                     verbose=shared.joblib_log_level(cf.LOG_LEVEL))(
                 delayed(_prepifg_multiprocessing)(p, xlooks, ylooks, exts, thresh, crop,
                         params) for p in gtiff_paths)
         else:

--- a/pyrate/shared.py
+++ b/pyrate/shared.py
@@ -60,6 +60,14 @@ GDAL_Y_CELLSIZE = 5
 GDAL_X_FIRST = 0
 GDAL_Y_FIRST = 3
 
+def joblib_log_level(level: str) -> int:
+    """
+    Convert python log level to joblib int verbosity.
+    """ 
+    if level == 'INFO':
+        return 0
+    else:
+        return 60
 
 def mkdir_p(path):
     """

--- a/pyrate/timeseries.py
+++ b/pyrate/timeseries.py
@@ -20,6 +20,7 @@ inversion in PyRate.
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-arguments
 import itertools
+
 from numpy import (where, isnan, nan, diff, zeros,
                    float32, cumsum, dot, delete, asarray)
 from numpy.linalg import matrix_rank, pinv, cholesky
@@ -31,6 +32,7 @@ from pyrate.algorithm import master_slave_ids, get_epochs
 from pyrate import config as cf
 from pyrate.config import ConfigException
 from pyrate import mst as mst_module
+from pyrate.shared import joblib_log_level
 
 
 def _time_series_setup(ifgs, mst, params):
@@ -139,7 +141,8 @@ def time_series(ifgs, params, vcmt=None, mst=None):
         _time_series_setup(ifgs, mst, params)
 
     if parallel == 1:
-        tsvel_matrix = Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        tsvel_matrix = Parallel(n_jobs=params[cf.PROCESSES], 
+                                verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_time_series_by_rows)(r, b0_mat, sm_factor, sm_order,
                                           ifg_data, mst, ncols, nvelpar,
                                           p_thresh, vcmt, ts_method, interp)
@@ -147,7 +150,8 @@ def time_series(ifgs, params, vcmt=None, mst=None):
 
     elif parallel == 2:
 
-        res = np.array(Parallel(n_jobs=params[cf.PROCESSES], verbose=50)(
+        res = np.array(Parallel(n_jobs=params[cf.PROCESSES], 
+                                verbose=joblib_log_level(cf.LOG_LEVEL))(
             delayed(_time_series_by_pixel)(i, j, b0_mat, sm_factor, sm_order,
                                            ifg_data, mst, nvelpar, p_thresh,
                                            interp, vcmt, ts_method)


### PR DESCRIPTION
This ties to the joblib verbosity to the PyRate verobisty - joblib messages will be disabled unless "DEBUG" is set as log level. I've also removed the MPI warning by setting an environment variable in the __init__ of the pyrate module.