### PR TITLE
Implement file lists for coherence and header files.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,6 +9,74 @@ format interferograms are contained in the example configuration file *input_par
 
 .. _parameters: https://geoscienceaustralia.github.io/PyRate/config.html
 
+File Discovery
+~~~~~~~~~~~~~~
+
+To allow flexibility in the file types the can be processed, PyRate requires
+file lists to be provided. This allow PyRate to identify what files are of
+which type without relying on file extensions. The path to 
+these lists are provided under the following keywords in the configuration 
+file:
+
+.. note::
+    
+    Filenames should be provided without the preceding path, wtih each
+    name on a separate line.
+    
+``ifgfilelist``: this is the list of interferograms to be processed.
+
+.. note::
+
+    Interferogram filenames must contain an epoch pair. Any naming convention 
+    is appropriate so long as an epoch pair of format ``XXXXXXXX-YYYYYYYY`` 
+    exists in the filename. 
+
+    Example of an interferogram file list:
+    ::
+
+        20150702-20150920_interferogram
+        20151219-20160109_interferogram
+        20160202-20160415_interferogram
+    
+``slcfilelist``: this is the list which contains the pool of available
+GAMMA headers. 
+
+.. note::
+
+    Header filenames must contain an epoch. The epoch must be
+    in the format ``XXXXXXXXX``.
+
+    Example of a GAMMA header file list:
+    ::
+
+        20150702_header
+        20150920_header
+        20151219_header
+        20160109_header
+        20160202_header
+        20160415_header
+       
+``cohfilelist``: this is the list which contains the pool of available
+coherence files (used in optional coherence masking). 
+
+.. note::
+
+    Coherence filenames must contain an epoch pair. The epoch pair must be 
+    in the format ``XXXXXXX-YYYYYYYY``.
+
+    Example of a coherence file list:
+    ::
+
+        20150702-20150920_coherence
+        20151219-20160109_coherence
+        20160202-20160415_coherence
+    
+The epochs in filenames are used to match the corresponding header or coherence
+files to each interferogram. It is recommended to provide all available headers/coherence 
+files in their respective lists, as only the necessary files will be
+used. This allows you to process a subset of interferograms by reducing
+the names in ``ifgfilelist`` without needing to modify anything else.
+    
 
 Workflow
 --------
@@ -79,25 +147,23 @@ specified at the *processor:* keyword in the config file (0: ROI\_PAC;
 
 Each GAMMA geocoded unwrapped interferogram requires three header files
 to extract metadata required for data formatting: a geocoded DEM header
-file (*\*.dem.par*), and the master and slave epoch SLC parameter files
-(*\*.slc.par*).
-
-The path and name of the DEM header file are specified in the config
-file under the *demHeaderFile:* keyword.
+file (``demHeaderFile`` in config) and the master and slave epoch SLC 
+parameter files (supplied by ``slcfilelist`` in config).
 
 The SLC parameter files should be in the directory specified in the
-config file under the *slcFileDir:* keyword. SLC parameter files for a
+config file under ``slcFileDir``. SLC files for a
 particular interferogram are found automatically by date-string pattern
-matching.
+matching based on epochs. If ``slcFileDir`` is not provided, PyRate will
+fallback to looking in the observations direcotry (``obsdir`` in config). 
 
 Each ROI\_PAC geocoded unwrapped interferogram requires its own
-header/resource file (*\*.unw.rsc*). These header files need to be
+header/resource file. These header files need to be
 stored in the same directory as the interferograms.
 
-In addition, the geocoded DEM header file (*\*.dem.rsc*) is required and
-its path and name are specified in the config file under the
-*demHeaderFile:* keyword. The geographic projection in the parameter
-*DATUM:* is extracted from the DEM header file.
+In addition, the geocoded DEM header file is required and
+its path and name are specified in the config file under ``demHeaderFile``.
+The geographic projection in the parameter *DATUM:* is extracted from the DEM 
+header file.
 
 Upon completion, geotiff formatted copies of the input files will be placed
 in the directory the input files are located in. Note that ``converttogeotiff``
@@ -132,19 +198,13 @@ If specified, ``prepifg`` will perform coherence masking of the unwrapped
 interferogram before multilooking and cropping is performed. This requires
 corresponding coherence images for each unwrapped interferogram. 
 
-The masking is performed with the raster calcuation:
-
-.. math::
-    B*(A>=T)+NDV*(A<T)
-
-where ``B`` is the coherence band, ``A`` is the intergerogram band, ``T`` is
-the coherence threshold and ``NDV`` is the interferogram no data value.
-
 Coherence masking is enabled  by setting the ``cohmask`` argument to ``1`` in
 the configuration file. A threshold, ``cohthresh`` needs to be provided. If
 ``cohfiledir`` is provided, this is where PyRate will look for coherence 
 images. If not provided it will look in observations directory where the
-unwrapped interferograms exist.
+unwrapped interferograms exist (``obsdir`` in config). The available coherence 
+filenames need tospecified in a file list and provided as the 
+``cohfilelist`` parameter.
 
 Image transformations: multilooking and cropping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -195,7 +255,7 @@ operation to estimate and remove atmospheric phase screen signals is
 applied to the interferograms prior to time series and linear rate
 analysis. The corrected interferograms are updated on disk and the
 corrections are not re-applied upon subsequent runs. This functionality
-is controlled by the *orbfit:* and *apsest:* options in the
+is controlled by the ``orbfit`` and ``apsest`` options in the
 configuration file.
 
 Non-optional pre-processing steps include: - Minimum Spanning Tree

--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -18,7 +18,7 @@ demHeaderFile: tests/test_data/small_test/gamma_obs/20060619_utm_dem.par
 slcFileDir:   tests/test_data/small_test/gamma_obs
 
 # GAMMA only: File listing the pool of available SLC headers.
-slcfilelist:
+slcfilelist: tests/test_data/small_test/gamma_obs/headers
 
 # Where to write the outputs
 outdir:       out/

--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -17,6 +17,9 @@ demHeaderFile: tests/test_data/small_test/gamma_obs/20060619_utm_dem.par
 # GAMMA only: The directory containing GAMMA slc.par files for all epochs
 slcFileDir:   tests/test_data/small_test/gamma_obs
 
+# GAMMA only: File listing the pool of available SLC headers.
+slcfilelist:
+
 # Where to write the outputs
 outdir:       out/
 
@@ -46,9 +49,11 @@ processes: 8
 # cohmask: 1 = ON, 0 = OFF
 # cohthresh: coherence threshold value
 # cohfiledir: directory containing the coherence file. If not provided, obsdir will be used.
+# cohfilelist: file listing the pool of available coherence files.
 cohmask:   0
-cohthresh:  0.6
+cohthresh:  0.1
 cohfiledir: 
+cohfilelist:
 
 #------------------------------------
 # Interferogram multi-look and crop options

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -509,9 +509,12 @@ def coherence_path_for(path, params, tif=False) -> str:
                       f"exist in {coherence_dir}. Found:\n {coherence_name}")
     else:
         if tif:
-            coherence_name = coherence_name[0] + '.tif'
+            name, ext = os.path.splitext(coherence_name[0])
+            tif_ext = ext.replace('.', '_') + '.tif'
+            coherence_name = name + tif_ext
         else:
             coherence_name = coherence_name[0]
+
         return os.path.join(coherence_dir, coherence_name)
 
 def coherence_paths(params) -> List[str]:

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -479,11 +479,11 @@ def original_ifg_paths(ifglist_path):
 def coherence_path_for(path, params, tif=False) -> str:
     """
     Returns path to coherence file for given interferogram. Pattern matches
-    based on an expected filename of {epoch}*{extension}.
+    based on epoch in filename.
     
     Example:
         '20151025-20160501_eqa_filt.cc'
-        Datepair is the epoch, .cc is the extension.
+        Datepair is the epoch.
 
     Args:
         path: Path to intergerogram to find coherence file for.

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -51,6 +51,8 @@ DEM_FILE = 'demfile'
 DEM_HEADER_FILE = 'demHeaderFile'
 #: STR; Name of directory containing GAMMA SLC parameter files
 SLC_DIR = 'slcFileDir'
+# STR; Name of the file list containing the pool of available SLC headers
+SLC_FILE_LIST = 'slcfilelist'
 
 
 #: STR; The projection of the input interferograms.
@@ -104,6 +106,8 @@ COH_THRESH = 'cohthresh'
 """float: coherence treshold"""
 COH_FILE_DIR = 'cohfiledir'
 """str: Directory containing coherence .cc files. Defaults to OBS_DIR if not provided."""
+COH_FILE_LIST = 'cohfilelist'
+"""str: Name of the file list containing the pool of available coherence files"""
 
 #atmospheric error correction parameters NOT CURRENTLY USED
 APS_CORRECTION = 'apscorrect'
@@ -274,7 +278,7 @@ PARAM_CONVERSION = {
 
 PATHS = [OBS_DIR, IFG_FILE_LIST, DEM_FILE,
          DEM_HEADER_FILE, OUT_DIR,
-         SLC_DIR, COH_FILE_DIR,
+         SLC_DIR, SLC_FILE_LIST, COH_FILE_DIR, COH_FILE_LIST,
          APS_INCIDENCE_MAP,
          APS_ELEVATION_MAP]
 

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -282,6 +282,8 @@ PATHS = [OBS_DIR, IFG_FILE_LIST, DEM_FILE,
          APS_INCIDENCE_MAP,
          APS_ELEVATION_MAP]
 
+DEFAULT_TO_OBS_DIR = [SLC_DIR, COH_FILE_DIR]
+
 INT_KEYS = [APS_CORRECTION, APS_METHOD]
 
 def get_config_params(path):
@@ -365,18 +367,20 @@ def _parse_pars(pars):
     """
     Parses and converts config file params from text
     """
+    # Fallback to default for missing values and perform conversion.
     for k in PARAM_CONVERSION:
-        if k in pars:
-            # if option value is blank/missing revert to default
-            if pars[k] is None:
-                pars[k] = PARAM_CONVERSION[k][1]
+        if pars.get(k) is None:
+            pars[k] = PARAM_CONVERSION[k][1]
+        else:
             conversion_func = PARAM_CONVERSION[k][0]
             if conversion_func:
                 pars[k] = conversion_func(pars[k])
-        else:
-            # revert missing options to default value
-            if k in PARAM_CONVERSION:
-                pars[k] = PARAM_CONVERSION[k][1]
+
+    # Fallback to default for missing paths.
+    for p in DEFAULT_TO_OBS_DIR:
+        if pars.get(p) is None:
+            pars[p] = pars[OBS_DIR]
+
     return pars
 
 def parse_namelist(nml):

--- a/pyrate/core/gamma.py
+++ b/pyrate/core/gamma.py
@@ -224,7 +224,6 @@ def get_header_paths(input_file, slc_file_list, slc_dir):
     epochs = PTN.findall(file_name)
     header_names = cf.parse_namelist(slc_file_list)
     matches = [hdr for hdr in header_names if any(e in hdr for e in epochs)]
-    print(f"{input_file}: {matches}")
     return [os.path.join(slc_dir, hdr) for hdr in matches]
 
 def gamma_header(ifg_file_path, params):
@@ -236,7 +235,8 @@ def gamma_header(ifg_file_path, params):
         params: PyRate parameters dictionary.
 
     Returns:
-        
+        A combined header dictionary containing metadata from matching
+        gamma headers and DEM header.   
     """
     dem_hdr_path = params[cf.DEM_HEADER_FILE]
     slc_dir = params[cf.SLC_DIR]

--- a/pyrate/core/gamma.py
+++ b/pyrate/core/gamma.py
@@ -17,15 +17,14 @@
 This Python module contains tools for reading GAMMA format input data.
 """
 # coding: utf-8
-
 from os.path import join, split
 import re
 import os
-import glob2
 from datetime import date, time, timedelta
 import numpy as np
 import pyrate.core.ifgconstants as ifc
 from pyrate.core import config as cf
+
 
 PTN = re.compile(r'\d{8}')  # match 8 digits for the dates
 
@@ -44,7 +43,6 @@ GAMMA_INCIDENCE = 'incidence_angle'
 RADIANS = 'RADIANS'
 GAMMA = 'GAMMA'
 
-
 def _parse_header(path):
     """Parses all GAMMA header file fields into a dictionary"""
     with open(path) as f:
@@ -53,7 +51,6 @@ def _parse_header(path):
 
     # convert the content into a giant dict of all key, values
     return dict((i[0][:-1], i[1:]) for i in raw_segs)
-
 
 def parse_epoch_header(path):
     """
@@ -82,7 +79,6 @@ def parse_epoch_header(path):
 
     return subset
 
-
 def _parse_date_time(lookup):
     """Grab date and time metadata and convert to datetime objects"""
     subset = {}
@@ -106,7 +102,6 @@ def _parse_date_time(lookup):
     subset[ifc.MASTER_TIME] = time(hour, min, sec)
 
     return subset
-
 
 def parse_dem_header(path):
     """
@@ -137,13 +132,11 @@ def parse_dem_header(path):
     subset[ifc.PYRATE_INSAR_PROCESSOR] = GAMMA
     return subset
 
-
 def _frequency_to_wavelength(freq):
     """
     Convert radar frequency to wavelength
     """
     return ifc.SPEED_OF_LIGHT_METRES_PER_SECOND / freq
-
 
 def combine_headers(hdr0, hdr1, dem_hdr):
     """
@@ -195,7 +188,6 @@ def combine_headers(hdr0, hdr1, dem_hdr):
     chdr.update(dem_hdr)  # add geographic data
     return chdr
 
-
 def manage_headers(dem_header_file, header_paths):
     """
     Manage and combine  header files for GAMMA interferograms, DEM and
@@ -219,8 +211,7 @@ def manage_headers(dem_header_file, header_paths):
 
     return combined_header
 
-
-def get_header_paths(input_file, slc_dir):
+def get_header_paths(input_file, slc_file_list, slc_dir):
     """
     Function that matches input GAMMA file names with GAMMA header file names
 
@@ -230,24 +221,34 @@ def get_header_paths(input_file, slc_dir):
     :rtype: list
     """
     _, file_name = split(input_file)
-    matches = PTN.findall(file_name)
-    headers = [glob2.glob(join(slc_dir, '**/*%s*slc.par' % m))[0]
-            	for m in matches]
-    return headers
+    epochs = PTN.findall(file_name)
+    header_names = cf.parse_namelist(slc_file_list)
+    matches = [hdr for hdr in header_names if any(e in hdr for e in epochs)]
+    print(f"{input_file}: {matches}")
+    return [os.path.join(slc_dir, hdr) for hdr in matches]
 
-
-def gamma_header(file_path, params):
+def gamma_header(ifg_file_path, params):
     """
     Function to obtain combined Gamma headers for image file
+    
+    Args:
+        ifg_file_path: Path to interferogram file to find headers for.
+        params: PyRate parameters dictionary.
+
+    Returns:
+        
     """
     dem_hdr_path = params[cf.DEM_HEADER_FILE]
     slc_dir = params[cf.SLC_DIR]
     # If no slc_dir provided, look for headers in obs dir.
+    # TODO: implement this as a default in config module.
     slc_dir = params[cf.OBS_DIR] if slc_dir is None else slc_dir
-    header_paths = get_header_paths(file_path, slc_dir=slc_dir)
+    header_paths = get_header_paths(ifg_file_path, 
+                                    params[cf.SLC_FILE_LIST], 
+                                    slc_dir=slc_dir)
     combined_headers = manage_headers(dem_hdr_path, header_paths)
 
-    if os.path.basename(file_path).split('.')[1] == \
+    if os.path.basename(ifg_file_path).split('.')[1] == \
             (params[cf.APS_INCIDENCE_EXT] or params[cf.APS_ELEVATION_EXT]):
         # TODO: implement incidence class here
         combined_headers['FILE_TYPE'] = 'Incidence'

--- a/pyrate/core/gamma.py
+++ b/pyrate/core/gamma.py
@@ -240,9 +240,6 @@ def gamma_header(ifg_file_path, params):
     """
     dem_hdr_path = params[cf.DEM_HEADER_FILE]
     slc_dir = params[cf.SLC_DIR]
-    # If no slc_dir provided, look for headers in obs dir.
-    # TODO: implement this as a default in config module.
-    slc_dir = params[cf.OBS_DIR] if slc_dir is None else slc_dir
     header_paths = get_header_paths(ifg_file_path, 
                                     params[cf.SLC_FILE_LIST], 
                                     slc_dir=slc_dir)

--- a/tests/common.py
+++ b/tests/common.py
@@ -44,6 +44,7 @@ SML_TEST_OUT = join(SML_TEST_DIR, 'out')
 SML_TEST_TIF = join(SML_TEST_DIR, 'tif')
 SML_TEST_GAMMA = join(SML_TEST_DIR, 'gamma_obs')  # gamma processed unws
 SML_TEST_CONF = join(SML_TEST_DIR, 'conf')
+SML_TEST_GAMMA_HEADER_LIST = join(SML_TEST_GAMMA, 'headers')
 
 SML_TEST_DEM_DIR = join(SML_TEST_DIR, 'dem')
 SML_TEST_LEGACY_PREPIFG_DIR = join(SML_TEST_DIR, 'prepifg_output')

--- a/tests/test_data/small_test/conf/pyrate_gamma_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_gamma_test.conf
@@ -15,6 +15,8 @@ demHeaderFile: tests/test_data/small_test/gamma_obs/20060619_utm_dem.par
 # GAMMA only: The directory containing GAMMA slc.par files for all epochs
 slcFileDir:   tests/test_data/small_test/gamma_obs
 
+slcfilelist: tests/test_data/small_test/gamma_obs/headers
+
 # Where to write the outputs
 outdir:       out/
 

--- a/tests/test_data/small_test/gamma_obs/headers
+++ b/tests/test_data/small_test/gamma_obs/headers
@@ -1,0 +1,13 @@
+20060619_slc.par
+20060828_slc.par
+20061002_slc.par
+20061106_slc.par
+20061211_slc.par
+20070115_slc.par
+20070219_slc.par
+20070326_slc.par
+20070430_slc.par
+20070604_slc.par
+20070709_slc.par
+20070813_slc.par
+20070917_slc.par

--- a/tests/test_gamma_vs_roipac.py
+++ b/tests/test_gamma_vs_roipac.py
@@ -42,6 +42,7 @@ from pyrate.core.config import (
     NO_DATA_AVERAGING_THRESHOLD,
     INPUT_IFG_PROJECTION,
     SLC_DIR,
+    SLC_FILE_LIST,
     DEM_FILE,
     APS_INCIDENCE_MAP,
     APS_ELEVATION_MAP
@@ -93,6 +94,8 @@ class TestGammaVsRoipacEquality(unittest.TestCase):
             conf.write('{}: {}\n'.format(IFG_CROP_OPT, '1'))
             conf.write('{}: {}\n'.format(NO_DATA_AVERAGING_THRESHOLD, '0.5'))
             conf.write('{}: {}\n'.format(SLC_DIR, ''))
+            conf.write('{}: {}\n'.format(SLC_FILE_LIST, 
+                                         common.SML_TEST_GAMMA_HEADER_LIST))
             conf.write('{}: {}\n'.format(DEM_FILE, common.SML_TEST_DEM_GAMMA))
             conf.write('{}: {}\n'.format(APS_INCIDENCE_MAP,
                                          common.SML_TEST_INCIDENCE))

--- a/tests/test_prepifg.py
+++ b/tests/test_prepifg.py
@@ -47,6 +47,7 @@ from pyrate.core.config import (
     PROCESSOR,
     OUT_DIR,
     SLC_DIR,
+    SLC_FILE_LIST,
     IFG_LKSX,
     IFG_LKSY,
     IFG_CROP_OPT,
@@ -688,6 +689,8 @@ class TestOneIncidenceOrElevationMap(unittest.TestCase):
             conf.write('{}: {}\n'.format(IFG_CROP_OPT, '1'))
             conf.write('{}: {}\n'.format(NO_DATA_AVERAGING_THRESHOLD, '0.5'))
             conf.write('{}: {}\n'.format(SLC_DIR, ''))
+            conf.write('{}: {}\n'.format(SLC_FILE_LIST,
+                                         common.SML_TEST_GAMMA_HEADER_LIST))
             conf.write('{}: {}\n'.format(DEM_FILE, common.SML_TEST_DEM_GAMMA))
             conf.write('{}: {}\n'.format(APS_INCIDENCE_MAP, inc))
             conf.write('{}: {}\n'.format(APS_ELEVATION_MAP, ele))


### PR DESCRIPTION
Rather than relying on extensions to identify file types we will now use lists for coherence and GAMMA header files in the same way as intergerogram file lists.

The new parameters are `slcfilelist` and `cohfilelist.`

Another addition is that `cohfiledir` and `slcFileDir` will fallback on `obsdir` as a default if they aren't provided.

Usage documentation has been updated to reflect this.