### PR TITLE
Validation refactor

### DIFF
--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -74,13 +74,12 @@ ifgylast:     -34.22
 
 #------------------------------------
 # Reference pixel search options
-# refx/y:  geographic coordinate of reference pixel. If value is out of bound for latitude/longitude
-# then search for pixel will be performed
+# refx/y:  geographic coordinate of reference pixel; if left blank, a reference pixel search is performed
 # refnx/y: number of search grid points in x/y direction
 # refchipsize: chip size of the data window at each search grid point
 # refminfrac: minimum fraction of valid (non-NaN) pixels in the data window
-refx:          150.911666666
-refy:          -34.18
+refx:          
+refy:          
 refnx:         5
 refny:         5
 refchipsize:   5

--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -74,7 +74,8 @@ ifgylast:     -34.22
 
 #------------------------------------
 # Reference pixel search options
-# refx/y:  geographic coordinate of reference pixel; if left blank, a reference pixel search is performed
+# refx/y: geographic latitude/longitude coordinate of reference pixel. If either is 
+#         blank a search for the best reference pixel will be performed.
 # refnx/y: number of search grid points in x/y direction
 # refchipsize: chip size of the data window at each search grid point
 # refminfrac: minimum fraction of valid (non-NaN) pixels in the data window

--- a/pyrate/__init__.py
+++ b/pyrate/__init__.py
@@ -12,3 +12,9 @@ __version__ = pkg_resources.require("Py-Rate")[0].version
 
 # Turn off MPI warning
 os.environ['OMPI_MCA_btl_base_warn_component_unused'] = '0'
+
+# Step name constants
+CONV2TIF = 'conv2tif'
+PREPIFG = 'prepifg'
+PROCESS = 'process'
+MERGE = 'merge'

--- a/pyrate/__main__.py
+++ b/pyrate/__main__.py
@@ -22,16 +22,11 @@ import argparse
 from argparse import RawTextHelpFormatter
 from pyrate.core import config as cf
 from pyrate import (conv2tif, prepifg, process, merge)
+from pyrate import CONV2TIF, PREPIFG, PROCESS, MERGE # Step names
 from pyrate import __version__
 from pyrate.core import pyratelog
 
 log = logging.getLogger(__name__)
-
-# Step names, used here and in config.py
-CONV2TIF = 'conv2tif' # legacy name: converttogeotiff
-PREPIFG = 'prepifg'
-PROCESS = 'process'
-MERGE = 'merge' # legacy name: postprocess
 
 def converttogeotiff_handler(config_file):
     """

--- a/pyrate/__main__.py
+++ b/pyrate/__main__.py
@@ -144,7 +144,7 @@ def main():
                                       "previously in main workflow."))
         
     parser_process.add_argument(*verbosity_args, **verbosity_kwargs)
-t 
+ 
     # create the parser for the "merge" command
     parser_postprocess = subparsers.add_parser('merge',
                                            help=("Reassemble computed tiles "

--- a/pyrate/__main__.py
+++ b/pyrate/__main__.py
@@ -38,7 +38,7 @@ def converttogeotiff_handler(config_file):
     Convert interferograms to geotiff.
     """
     config_file = os.path.abspath(config_file)
-    params = cf.get_config_params(config_file, requires_tif=False)
+    params = cf.get_config_params(config_file, step=CONV2TIF)
     conv2tif.main(params)
 
 
@@ -47,7 +47,7 @@ def prepifg_handler(config_file):
     Perform multilooking and cropping on geotiffs.
     """
     config_file = os.path.abspath(config_file)
-    params = cf.get_config_params(config_file, requires_tif=True)
+    params = cf.get_config_params(config_file, step=PREPIFG)
     prepifg.main(params)
 
 
@@ -56,7 +56,7 @@ def process_handler(config_file, rows, cols):
     Time series and linear rate computation.
     """
     config_file = os.path.abspath(config_file)
-    _, dest_paths, params = cf.get_ifg_paths(config_file, requires_tif=True)
+    _, dest_paths, params = cf.get_ifg_paths(config_file, step=PROCESS)
     process.process_ifgs(sorted(dest_paths), params, rows, cols)
 
 
@@ -65,7 +65,7 @@ def postprocess_handler(config_file, rows, cols):
     Reassemble computed tiles and save as geotiffs.
     """
     config_file = os.path.abspath(config_file)
-    _, _, params = cf.get_ifg_paths(config_file, requires_tif=True)
+    _, _, params = cf.get_ifg_paths(config_file, step=MERGE)
     merge.main(params, rows, cols)
 
 CLI_DESC = """
@@ -149,7 +149,7 @@ def main():
                                       "previously in main workflow."))
         
     parser_process.add_argument(*verbosity_args, **verbosity_kwargs)
-
+t 
     # create the parser for the "merge" command
     parser_postprocess = subparsers.add_parser('merge',
                                            help=("Reassemble computed tiles "

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -882,6 +882,7 @@ def validate_parameters(pars: Dict, step: str=CONV2TIF):
             _get_fullres_info(ifl, pars[OBS_DIR], _crop_opts(pars))
 
         validate_crop_parameters(min_extents, pars)
+        validate_multilook_parameters(n_cols, n_rows, IFG_LKSX, IFG_LKSY, pars)
 
         # Check coherence masking if enabled
         if pars[COH_MASK]:

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -1360,6 +1360,7 @@ def validate_multilook_parameters(cols: int, rows: int,
             return (f"'{var_name}': the multilook factor ({pars[var_name]}) "
                     f"must be less than the number of pixels on the {dim_str} "
                     f"axis ({dim_val}).")
+        return []
 
     errors.extend(_validate_mlook(xlks_name, cols, 'x'))
     errors.extend(_validate_mlook(ylks_name, rows, 'y'))

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -33,7 +33,6 @@ import logging
 
 from pyrate.core.ifgconstants import YEARS_PER_DAY
 from pyrate import CONV2TIF, PREPIFG, PROCESS, MERGE
-from pyrate.core.shared import Ifg, output_tiff_filename
 
 _logger = logging.getLogger(__name__)
 
@@ -1454,6 +1453,7 @@ def _get_temporal_info(ifg_file_list: str, obs_dir: str) -> Tuple:
         Tuple containing the number of unique epochs and the maximum timespan.
     """
     from pyrate.core.algorithm import get_epochs
+    from pyrate.core.shared import Ifg, output_tiff_filename
 
     ifg_paths = \
         [os.path.join(obs_dir, ifg) for ifg in parse_namelist(ifg_file_list)]
@@ -1485,6 +1485,8 @@ def _get_prepifg_info(ifg_file_list: str, obs_dir: str, pars: Dict) -> Tuple:
 
     Returns:
     """
+    from pyrate.core.shared import Ifg
+
     base_paths = [os.path.join(obs_dir, ifg) for ifg in parse_namelist(ifg_file_list)]
     ifg_paths = get_dest_paths(base_paths, pars[IFG_CROP_OPT], pars, pars[IFG_LKSX])
 
@@ -1518,6 +1520,7 @@ def _get_fullres_info(ifg_file_list: str, obs_dir: str, crop_opts: Tuple) -> Tup
         time span of the data.
     """
     from pyrate.core.prepifg_helper import _min_bounds, _get_extents
+    from pyrate.core.shared import Ifg, output_tiff_filename
 
     ifg_paths = [os.path.join(obs_dir, ifg) for ifg in parse_namelist(ifg_file_list)]
     rasters = [Ifg(output_tiff_filename(f, obs_dir)) for f in ifg_paths]

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -284,8 +284,8 @@ def get_config_params(path: str, validate: bool=True, step: str=CONV2TIF) -> Dic
     Args:
         path: Absolute path to the parameters file.
         validate: Validate the parameters if True, otherwise skip validation.
-        requires_tif: True if the calling process requires interferograms
-            in geotiff format (performs additional validation).
+        step: The current step of the PyRate workflow.
+
     Returns:
        A dictionary of parameters. 
     """
@@ -821,7 +821,18 @@ _REFERENCE_PIXEL_VALIDATION = {
 """dict: basic validation functions for reference pixel search parameters."""
 
 def convert_geographic_coordinate_to_pixel_value(refpx, refpy, transform):
+    """
+    Converts a lat/long coordinate to a pixel coordinate given the 
+    geotransform of the image.
 
+    Args:
+        refpx: The longitude of the coordinate.
+        refpx: The latitude of the coordinate.
+        transform: The geotransform array of the image.
+
+    Returns:
+        Tuple of refpx, refpy in pixel values.
+    """
     # transform = ifg.dataset.GetGeoTransform()
 
     xOrigin = transform[0]
@@ -1082,6 +1093,17 @@ def validate_prepifg_tifs_exist(
     """
     Validates that cropped and multilooked interferograms exist in geotiff
     format.
+
+    Args:
+        ifg_file_list: Path to file containing interfergram file names.
+        obs_dir: Path to observations directory.
+        pars: Parameters dictionary.
+
+    Returns:
+        True if all interferograms exist in geotiff format.
+
+    Raises:
+        ConfigException: If not all intergerograms exist in geotiff format.
     """
     errors = []
     base_paths = [os.path.join(obs_dir, ifg) for ifg in parse_namelist(ifg_file_list)]

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -915,6 +915,7 @@ def validate_parameters(pars: Dict, step: str=CONV2TIF):
         # Convert refx/refy from lat/long to pixel.
         pars[REFX], pars[REFY] = \
             convert_geographic_coordinate_to_pixel_value(pars[REFX], pars[REFY], transform)
+
         validate_reference_pixel_params(n_cols, n_rows, pars[REFX], pars[REFY])
         validate_reference_pixel_search_windows(n_cols, n_rows, pars)
         validate_multilook_parameters(n_cols, n_rows, 
@@ -1323,11 +1324,11 @@ def validate_reference_pixel_params(looked_cols: int, looked_rows: int,
     # Check reference pixel coordinates within scene.
     if refx != 0 and refy != 0:
         if not 0 < refx <= looked_cols:
-            errors.append(f"'{REFX}': reference pixel coodinate is "
+            errors.append(f"'{REFX}': reference pixel coodinate {refx} is "
                           f"outside bounds of scene ({x_dim_string}).")
 
         if not 0 < refy <= looked_rows:
-            errors.append(f"'{REFY}': reference pixel coodinate is "
+            errors.append(f"'{REFY}': reference pixel coodinate {refy} is "
                           f"outside bounds of scene ({y_dim_string}).")
     
     return _raise_errors(errors)

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -555,7 +555,7 @@ def get_ifg_paths(config_file, step=CONV2TIF):
     :rtype: list
     :rtype: dict
     """
-    params = get_config_params(config_file, step)
+    params = get_config_params(config_file, step=step)
     ifg_file_list = params.get(IFG_FILE_LIST)
 
     xlks, _, crop = transform_params(params)
@@ -915,7 +915,6 @@ def validate_parameters(pars: Dict, step: str=CONV2TIF):
         # Convert refx/refy from lat/long to pixel.
         pars[REFX], pars[REFY] = \
             convert_geographic_coordinate_to_pixel_value(pars[REFX], pars[REFY], transform)
-        
         validate_reference_pixel_params(n_cols, n_rows, pars[REFX], pars[REFY])
         validate_reference_pixel_search_windows(n_cols, n_rows, pars)
         validate_multilook_parameters(n_cols, n_rows, 
@@ -1357,9 +1356,9 @@ def validate_multilook_parameters(cols: int, rows: int,
 
     def _validate_mlook(var_name, dim_val, dim_str):
         if pars[var_name] > dim_val:
-            return (f"'{var_name}': the multilook factor ({pars[var_name]}) "
+            return [f"'{var_name}': the multilook factor ({pars[var_name]}) "
                     f"must be less than the number of pixels on the {dim_str} "
-                    f"axis ({dim_val}).")
+                    f"axis ({dim_val})."]
         return []
 
     errors.extend(_validate_mlook(xlks_name, cols, 'x'))

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -1321,17 +1321,17 @@ def validate_reference_pixel_params(looked_cols: int, looked_rows: int,
         ConfigException: If validation fails.
     """
     errors = []
-    x_dim_string = f"(xmin: 0, xmax: {looked_cols}"
-    y_dim_string = f"(ymin: 0, ymax: {looked_rows}"
+    x_dim_string = f"xmin: 0, xmax: {looked_cols}"
+    y_dim_string = f"ymin: 0, ymax: {looked_rows}"
 
     # Check reference pixel coordinates within scene.
     if refx != 0 and refy != 0:
         if not 0 < refx <= looked_cols:
-            errors.append(f"'{REFX}': reference pixel coodinate {refx} is "
+            errors.append(f"'{REFX}': reference pixel coordinate {refx} is "
                           f"outside bounds of scene ({x_dim_string}).")
 
         if not 0 < refy <= looked_rows:
-            errors.append(f"'{REFY}': reference pixel coodinate {refy} is "
+            errors.append(f"'{REFY}': reference pixel coordinate {refy} is "
                           f"outside bounds of scene ({y_dim_string}).")
     
     return _raise_errors(errors)

--- a/pyrate/process.py
+++ b/pyrate/process.py
@@ -130,7 +130,7 @@ def _ref_pixel_calc(ifg_paths, params):
     ifg = Ifg(ifg_paths[0])
     ifg.open(readonly=True)
 
-    if refx < -180 or refx > 180 or refy < -90 or refy > 90:  # if either zero or negative
+    if refx == -1 or refy == -1: # these are the default refx/refy values
         log.info('Searching for best reference pixel location')
 
         half_patch_size, thresh, grid = refpixel.ref_pixel_setup(ifg_paths,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -623,8 +623,8 @@ class ConfigTest(unittest.TestCase):
         conf_path = join(SML_TEST_CONF, 'pyrate1.conf')
         params = config.get_config_params(conf_path)
 
-        assert params[config.REFX] == 181
-        assert params[config.REFY] == 91
+        assert params[REFX] == -1.
+        assert params[REFY] == -1.
 
     @staticmethod
     def test_read_param_file_missing_value():
@@ -632,8 +632,8 @@ class ConfigTest(unittest.TestCase):
         conf_path = join(SML_TEST_CONF, 'pyrate2.conf')
         params = config.get_config_params(conf_path)
 
-        assert params[config.REFX] == 181
-        assert params[config.REFY] == 91
+        assert params[REFX] == -1.
+        assert params[REFY] == -1.
 
     @staticmethod
     def test_parse_namelist():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+#
+# pylint: disable=trailing-whitespace, missing-docstring
 '''
 This Python module contains tests for the config.py PyRate module.
 '''
@@ -30,9 +32,14 @@ from pyrate.core import config
 from pyrate.core.config import (
     validate_parameters, validate_optional_parameters, validate_epochs,
     validate_obs_thresholds, validate_ifgs, validate_gamma_headers,
-    validate_coherence_files, validate_tifs_exist, validate_pixel_parameters,
-    validate_minimum_epochs, validate_epoch_thresholds, validate_epoch_cutoff,
-    validate_extent_parameters, validate_reference_pixel_search_windows)
+    validate_coherence_files, validate_tifs_exist, validate_minimum_epochs, 
+    validate_epoch_thresholds, validate_epoch_cutoff,
+    validate_crop_parameters, validate_slpf_cutoff,
+    validate_reference_pixel_search_windows,
+    validate_reference_pixel_params,
+    validate_multilook_parameters,
+    validate_prepifg_tifs_exist,
+    _get_temporal_info, _get_prepifg_info, _get_fullres_info)
 from pyrate.core.config import (
     SIXTEEN_DIGIT_EPOCH_PAIR,
     TWELVE_DIGIT_EPOCH_PAIR,
@@ -453,7 +460,8 @@ class TestConfigValidation(unittest.TestCase):
         with pytest.raises(ConfigException):
             validate_obs_thresholds(self.params[IFG_FILE_LIST], self.params)
 
-class TestConfigValidationWithGeotiffs(unittest.TestCase):
+
+class TestConfigValidationWithFullResGeotiffs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         from pyrate import conv2tif
@@ -466,14 +474,13 @@ class TestConfigValidationWithGeotiffs(unittest.TestCase):
         
     def setUp(self):
         self.params = config.get_config_params(TEST_CONF_GAMMA,
-                                               requires_tif=True)
+                                               'prepifg')
         self.dummy_dir = '/i/should/not/exist'
         crop_opts = config._crop_opts(self.params)
-        self.extents, self.min_extents, self.n_cols, self.n_rows, self.n_epochs, \
-        self.max_span, self.transform = \
-            config._get_ifg_information(self.params[IFG_FILE_LIST],
-                                        self.params[OBS_DIR],
-                                        crop_opts)
+        self.min_extents, self.n_cols, self.n_rows = \
+            config._get_fullres_info(self.params[IFG_FILE_LIST],
+                                     self.params[OBS_DIR],
+                                     crop_opts)
         if os.path.exists(self.dummy_dir):
             raise IOError("{dummy_dir} needs to not exist for test purposes.")
     
@@ -482,14 +489,95 @@ class TestConfigValidationWithGeotiffs(unittest.TestCase):
         with pytest.raises(ConfigException):
             validate_tifs_exist(self.params[IFG_FILE_LIST], self.dummy_dir)
 
+    def test_validate_ifg_crop_coordinates(self):
+        self.params[IFG_CROP_OPT] = 3
+        self.params[IFG_XFIRST] = 150.0
+        with pytest.raises(ConfigException):
+            validate_crop_parameters(self.min_extents, self.params)
+        self.params[IFG_XFIRST] = 150.92
+
+        self.params[IFG_XLAST] = 150.95
+        with pytest.raises(ConfigException):
+            validate_crop_parameters(self.min_extents, self.params)
+        self.params[IFG_XLAST] = 150.94
+
+        self.params[IFG_YFIRST] = -34.16
+        with pytest.raises(ConfigException):
+            validate_crop_parameters(self.min_extents, self.params)
+        self.params[IFG_YFIRST] = -34.18
+
+        self.params[IFG_YLAST] = -34.24
+        with pytest.raises(ConfigException):
+            validate_crop_parameters(self.min_extents, self.params)
+
+    def test_validate_ifg_multilook(self):
+        self.params[IFG_LKSX] = 48
+        self.params[IFG_LKSY] = 73
+        with pytest.raises(ConfigException):
+            validate_multilook_parameters(self.n_cols, self.n_rows,
+                                          IFG_LKSX, IFG_LKSY, self.params)
+    
+
+class TestConfigValidationWithPrepifgGeotiffs(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from pyrate import conv2tif, prepifg
+        cls.params = config.get_config_params(TEST_CONF_GAMMA)
+        conv2tif.main(cls.params)
+        prepifg.main(cls.params)
+    
+    @classmethod
+    def tearDownClass(cls):
+        common.remove_tifs(cls.params[OBS_DIR])
+        common.remove_tifs(cls.params[OUT_DIR])
+        
+    def setUp(self):
+        self.params = config.get_config_params(TEST_CONF_GAMMA,
+                                               'process')
+        self.dummy_dir = '/i/should/not/exist'
+        crop_opts = config._crop_opts(self.params)
+        self.extents, self.n_cols, self.n_rows, _ = \
+            _get_prepifg_info(self.params[IFG_FILE_LIST], self.params[OBS_DIR], 
+                              self.params)
+        self.n_epochs, self.max_span = \
+            _get_temporal_info(self.params[IFG_FILE_LIST], self.params[OBS_DIR])
+        if os.path.exists(self.dummy_dir):
+            raise IOError("{dummy_dir} needs to not exist for test purposes.")
+
+    def test_validate_prepifg_tifs_exist(self):
+        validate_prepifg_tifs_exist(self.params[IFG_FILE_LIST], 
+                                    self.params[OBS_DIR],
+                                    self.params)
+        with pytest.raises(ConfigException):
+            self.params[IFG_LKSX] = 100
+            validate_prepifg_tifs_exist(self.params[IFG_FILE_LIST],
+                                        self.params[OBS_DIR],
+                                        self.params)
+
+    def test_validate_epoch_thresholds(self):
+        with pytest.raises(ConfigException):
+            validate_minimum_epochs(self.n_epochs, 50)
+        
+        validate_epoch_thresholds(self.n_epochs, self.params)
+        self.params[LR_PTHRESH] = 20
+        with pytest.raises(ConfigException):
+            validate_epoch_thresholds(self.n_epochs, self.params)
+        self.params[LR_PTHRESH] = 5
+        
+        self.params[SLPF_CUTOFF] = 1000
+        with pytest.raises(ConfigException):
+            validate_epoch_cutoff(self.max_span, SLPF_CUTOFF, self.params)
+        
     def test_validate_refx_refy_parameters(self):
         self.params[REFX] = 20
         self.params[REFY] = 20
-        validate_pixel_parameters(self.n_cols, self.n_rows, self.params)
+        validate_reference_pixel_params(self.n_cols, self.n_rows, 
+                                        self.params[REFX], self.params[REFY])
         self.params[REFX] = 48
         self.params[REFY] = 73
         with pytest.raises(ConfigException):
-            validate_pixel_parameters(self.n_cols, self.n_rows, self.params)
+            validate_reference_pixel_params(self.n_cols, self.n_rows, 
+                                            self.params[REFX], self.params[REFY])
 
     def test_validate_search_windows(self):
         self.params[REF_CHIP_SIZE] = 21
@@ -505,56 +593,14 @@ class TestConfigValidationWithGeotiffs(unittest.TestCase):
         self.params[REFNY] = 4
         with pytest.raises(ConfigException):
             validate_reference_pixel_search_windows(self.n_cols, self.n_rows, self.params)
-
+    
     def test_validate_multilook_parameters(self):
-        self.params[IFG_LKSX] = 48
-        self.params[IFG_LKSY] = 73
-        with pytest.raises(ConfigException):
-            validate_pixel_parameters(self.n_cols, self.n_rows, self.params)
-        
-        self.params[IFG_LKSX] = 1
-        self.params[IFG_LKSY] = 1
         self.params[ORBITAL_FIT_LOOKS_X] = 48
         self.params[ORBITAL_FIT_LOOKS_Y] = 73
         with pytest.raises(ConfigException):
-            validate_pixel_parameters(self.n_cols, self.n_rows, self.params)       
+            validate_multilook_parameters(self.n_cols, self.n_rows,
+                ORBITAL_FIT_LOOKS_X, ORBITAL_FIT_LOOKS_Y, self.params)       
 
-    def test_validate_ifg_crop_coordinates(self):
-        self.params[IFG_CROP_OPT] = 3
-        self.params[IFG_XFIRST] = 150.0
-        with pytest.raises(ConfigException):
-            validate_extent_parameters(self.extents, self.min_extents, self.params)
-        self.params[IFG_XFIRST] = 150.92
-
-        self.params[IFG_XLAST] = 150.95
-        with pytest.raises(ConfigException):
-            validate_extent_parameters(self.extents, self.min_extents, self.params)
-        self.params[IFG_XLAST] = 150.94
-
-        self.params[IFG_YFIRST] = -34.16
-        with pytest.raises(ConfigException):
-            validate_extent_parameters(self.extents, self.min_extents, self.params)
-        self.params[IFG_YFIRST] = -34.18
-
-        self.params[IFG_YLAST] = -34.24
-        with pytest.raises(ConfigException):
-            validate_extent_parameters(self.extents, self.min_extents, self.params)
-    
-    def test_validate_epoch_thresholds(self):
-        with pytest.raises(ConfigException):
-            validate_minimum_epochs(self.n_epochs, 50)
-        
-        validate_epoch_thresholds(self.n_epochs, self.params)
-        self.params[LR_PTHRESH] = 20
-        with pytest.raises(ConfigException):
-            validate_epoch_thresholds(self.n_epochs, self.params)
-        self.params[LR_PTHRESH] = 5
-        
-        self.params[SLPF_CUTOFF] = 1000
-        with pytest.raises(ConfigException):
-            validate_epoch_cutoff(self.max_span, SLPF_CUTOFF, self.params)
-        
-        
 
 class ConfigTest(unittest.TestCase):
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -601,6 +601,11 @@ class TestConfigValidationWithPrepifgGeotiffs(unittest.TestCase):
             validate_multilook_parameters(self.n_cols, self.n_rows,
                 ORBITAL_FIT_LOOKS_X, ORBITAL_FIT_LOOKS_Y, self.params)       
 
+    def test_validate_slpf_cutoff(self):
+        self.params[SLPF_CUTOFF] = 9999
+        with pytest.raises(ConfigException):
+            validate_slpf_cutoff(self.extents, self.params)
+
 
 class ConfigTest(unittest.TestCase):
 


### PR DESCRIPTION
This aims to solve the issue of needing access to cropped/resampled interferograms for certain parameter checks. It does this by introducing the previously discussed idea of selectively running validation functions based on the current workflow step being run. _Note that bounds checking is still performed for every parameter regardless of what step is being run_ - this is an improvement that can be made in future.

The main thing to test here is that the previous failing checks (orbital looks, refx/y) now work.