### PR TITLE
Configurable venv location in nci_load_modules.

### DIFF
--- a/scripts/nci_load_modules.sh
+++ b/scripts/nci_load_modules.sh
@@ -4,4 +4,4 @@ module load python3/3.7.4
 module load gdal/3.0.2
 module load openmpi/2.1.6
 export PYTHONPATH=/apps/gdal/3.0.2/lib64/python3.7/site-packages:$PYTHONPATH
-source ~/PyRateVenv/bin/activate
+source ${PYRATE_VENV:-${HOME}/PyRateVenv}/bin/activate


### PR DESCRIPTION
Activate the venv from a configured location instead of "~". Falls back to the previous behaviour if no PYRATE_VENV is set in the environment.