### PR TITLE
Optional save of tsincr files

### DIFF
--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -18,6 +18,9 @@ tscal:      1
 # Optional save of numpy array files for output products (MERGE)
 savenpy:    0
 
+# Optional save of incremental time series products (PROCESS/MERGE)
+savetsincr: 0
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Multi-threading parameters used by stacking/timeseries/prepifg
 # gamma prepifg runs in parallel on a single machine if parallel = 1

--- a/pyrate/core/timeseries.py
+++ b/pyrate/core/timeseries.py
@@ -113,26 +113,25 @@ def time_series(ifgs, params, vcmt=None, mst=None):
     network. Solves the linear least squares system using either the SVD
     method (similar to the SBAS method implemented by Berardino et al. 2002)
     or a Finite Difference method using a Laplacian Smoothing operator
-    (similar to the method implemented by Schmidt and Burgmann 2003)
+    (similar to the method implemented by Schmidt and Burgmann 2003).
+    The returned outputs are multi-dimensional arrays of
+    size(nrows, ncols, nepochs-1), where:
+
+        - *nrows* is the number of rows in the ifgs,
+        - *ncols* is the  number of columns in the ifgs, and
+        - *nepochs* is the number of unique epochs (dates)
 
     :param list ifgs: list of interferogram class objects.
     :param dict params: Dictionary of configuration parameters
     :param ndarray vcmt: Positive definite temporal variance covariance matrix
     :param ndarray mst: [optional] Minimum spanning tree array.
 
-    :return: Tuple with the elements:
-
-        - incremental displacement time series,
-        - cumulative displacement time series, and
-        - velocity for the epoch interval
-
-        these outputs are multi-dimensional arrays of
-        size(nrows, ncols, nepochs-1), where:
-
-        - *nrows* is the number of rows in the ifgs,
-        - *ncols* is the  number of columns in the ifgs, and
-        - *nepochs* is the number of unique epochs (dates)
-    :rtype: tuple
+    :return: tsincr: incremental displacement time series.
+    :rtype: ndarray
+    :return: tscuml: cumulative displacement time series.
+    :rtype: ndarray
+    :return: tsvel_matrix: velocity for each epoch interval.
+    :rtype: ndarray
     """
 
     b0_mat, interp, p_thresh, sm_factor, sm_order, ts_method, ifg_data, mst, \
@@ -160,11 +159,11 @@ def time_series(ifgs, params, vcmt=None, mst=None):
     # SB: do the span multiplication as a numpy linalg operation, MUCH faster
     #  not even this is necessary here, perform late for performance
     tsincr = tsvel_matrix * span
-    tscum = cumsum(tsincr, 2)
+    tscuml = cumsum(tsincr, 2)
     # SB: perform this after tsvel_matrix has been nan converted,
     # saves the step of comparing a large matrix (tsincr) to zero.
-    # tscum = where(tscum == 0, nan, tscum)
-    return tsincr, tscum, tsvel_matrix
+    # tscuml = where(tscuml == 0, nan, tscuml)
+    return tsincr, tscuml, tsvel_matrix
 
 
 def _remove_rank_def_rows(b_mat, nvelpar, ifgv, sel):

--- a/pyrate/default_parameters.py
+++ b/pyrate/default_parameters.py
@@ -437,5 +437,13 @@ PYRATE_DEFAULT_CONFIGURATION = {
         "PossibleValues": [1, 0],
         "Required": False
     },
+    "savetsincr": {
+        "DataType": int,
+        "DefaultValue": 1,
+        "MinValue": 0,
+        "MaxValue": 1,
+        "PossibleValues": [1, 0],
+        "Required": False
+    },
 
 }

--- a/pyrate/process.py
+++ b/pyrate/process.py
@@ -414,9 +414,9 @@ def _timeseries_calc(ifg_paths, params, vcmt, tiles, preread_ifgs):
         log.debug("Calculating time series for tile "+str(t.index)+" out of "+str(total_tiles))
         ifg_parts = [shared.IfgPart(p, t, preread_ifgs, params) for p in ifg_paths]
         mst_tile = np.load(os.path.join(output_dir, 'mst_mat_{}.npy'.format(t.index)))
-        res = timeseries.time_series(ifg_parts, params, vcmt, mst_tile)
-        tsincr, tscum, _ = res
-        np.save(file=os.path.join(output_dir, 'tsincr_{}.npy'.format(t.index)), arr=tsincr)
-        np.save(file=os.path.join(output_dir, 'tscuml_{}.npy'.format(t.index)), arr=tscum)
+        tsincr, tscuml, _ = timeseries.time_series(ifg_parts, params, vcmt, mst_tile)
+        np.save(file=os.path.join(output_dir, 'tscuml_{}.npy'.format(t.index)), arr=tscuml)
+        # optional save of tsincr npy tiles
+        if params["savetsincr"] == 1: np.save(file=os.path.join(output_dir, 'tsincr_{}.npy'.format(t.index)), arr=tsincr)
     mpiops.comm.barrier()
     log.debug("Finished timeseries calc!")

--- a/tests/test_data/small_test/conf/pyrate_gamma_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_gamma_test.conf
@@ -164,3 +164,5 @@ cols: 2
 
 # optionally save stack numpy files during merge step
 savenpy: 1
+# optionally save tsincr file outputs
+savetsincr: 1

--- a/tests/test_data/small_test/conf/pyrate_roipac_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_roipac_test.conf
@@ -155,3 +155,11 @@ nsig:          3
 pthr:          5
 maxsig:        2
 
+# optionally supply rows and cols for tiles used during process and merge step
+rows: 3
+cols: 2
+
+# optionally save stack numpy files during merge step
+savenpy: 1
+# optionally save tsincr file outputs
+savetsincr: 1

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -50,8 +50,7 @@ def test_png_creation(create_stack_output):
 
     output_folder_path = params[cf.OUT_DIR]
 
-    rows, cols = params["rows"], params["cols"]
-    _merge_stack(rows, cols, params)
+    _merge_stack(params)
     _create_png_from_tif(output_folder_path)
 
     # check if color map is created


### PR DESCRIPTION
- make saving tsincr files (npy or tif) optional.
- controlled by new config parameter `savetsincr`
- default is on (`savetsincr=1`)
- saving of tscuml files is unaffected.