### PR TITLE
Remove Pillow dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,6 @@ The versions of each package stated above have been tested to work.
 
 Python dependencies for PyRate are::
 
-    Cython==0.29.16
     joblib==0.14.1
     mpi4py==3.0.3
     networkx==2.4

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,6 @@ The versions of each package stated above have been tested to work.
 Python dependencies for PyRate are::
 
     Cython==0.29.16
-    glob2==0.7
     joblib==0.14.1
     mpi4py==3.0.3
     networkx==2.4

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,6 @@ The versions of each package stated above have been tested to work.
 Python dependencies for PyRate are::
 
     Cython==0.29.16
-    Pillow==7.1.1
     glob2==0.7
     joblib==0.14.1
     mpi4py==3.0.3

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ The full PyRate documentation is available at http://geoscienceaustralia.github.
 Dependencies
 ------------
 
-The following dependencies need to be on your system prior to PyRate installation:
+The following system dependencies are required by PyRate:
 
 - `Python <https://www.python.org/downloads/>`_, versions 3.6, 3.7 or 3.8.
 - `GDAL <https://gdal.org/download.html>`_, versions 3.0.2 or 3.0.4
@@ -29,7 +29,7 @@ The following dependencies need to be on your system prior to PyRate installatio
 
 The versions of each package stated above have been tested to work.
 
-Python dependencies are::
+Python dependencies for PyRate are::
 
     Cython==0.29.16
     Pillow==7.1.1
@@ -47,7 +47,7 @@ Install
 
 Details of all install options are given in the `PyRate documentation <http://geoscienceaustralia.github.io/PyRate>`_.
 
-`PyRate` and its Python dependencies can be installed directly from the `Python Package Index (PyPI) <https://pypi.org/project/Py-Rate/>`_::
+PyRate and its Python dependencies can be installed directly from the `Python Package Index (PyPI) <https://pypi.org/project/Py-Rate/>`_::
 
     pip install Py-Rate
 
@@ -65,7 +65,7 @@ To learn more about using PyRate, type ``pyrate`` command in the terminal::
 
     >> pyrate --help
     usage: pyrate [-h] [-v {DEBUG,INFO,WARNING,ERROR}]
-                  {conv2tif,prepifg,correct,timeseires,stack,merge,workflow} ...
+              {conv2tif,prepifg,correct,timeseries,stack,merge,workflow} ...
 
     PyRate workflow:
 
@@ -80,14 +80,14 @@ To learn more about using PyRate, type ``pyrate`` command in the terminal::
     more details.
 
     positional arguments:
-      {conv2tif,prepifg,correct,merge,workflow}
+      {conv2tif,prepifg,correct,timeseries,stack,merge,workflow}
         conv2tif            Convert interferograms to geotiff.
-        prepifg             Perform multilooking and cropping on geotiffs.
-        correct             Main processing workflow including corrections
-        timeseries          Timeseries computation
-        stack               Stacking computation
+        prepifg             Perform multilooking, cropping and coherence masking to interferogram geotiffs.
+        correct             Calculate and apply corrections to interferogram phase data.
+        timeseries          Timeseries inversion of interferogram phase data.
+        stack               Stacking of interferogram phase data.
         merge               Reassemble computed tiles and save as geotiffs.
-        workflow            Run all the PyRate processes
+        workflow            Sequentially run all the PyRate processing steps.
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/pyrate/core/gdal_python.py
+++ b/pyrate/core/gdal_python.py
@@ -18,7 +18,6 @@ This Python module contains bindings for the GDAL library
 """
 # pylint: disable=too-many-arguments,R0914
 from osgeo import gdal, gdalconst, gdalnumeric
-from PIL import Image, ImageDraw
 import numpy as np
 import numexpr as ne
 from typing import Union, List, Tuple
@@ -86,118 +85,6 @@ def world_to_pixel(geo_transform, x, y):
     return col, line
 
 
-def crop(input_file, extents, geo_trans=None, nodata=np.nan):
-    """
-    Adapted from http://karthur.org/2015/clipping-rasters-in-python.html
-
-    Clips a raster (given as either a gdal.Dataset or as a numpy.array
-    instance) to a polygon layer provided by a Shapefile (or other vector
-    layer). If a numpy.array is given, a "GeoTransform" must be provided
-    (via dataset.GetGeoTransform() in GDAL). Returns an array. Clip features
-    must be a dissolved, single-part geometry (not multi-part). Modified from:
-
-    http://pcjericks.github.io/py-gdalogr-cookbook/raster_layers.html
-    #clip-a-geotiff-with-shapefile
-
-    Arguments:
-        rast            A gdal.Dataset or a NumPy array
-        features_path   The path to the clipping features
-        geo_trans              An optional GDAL GeoTransform to use instead
-        nodata          The NoData value; defaults to -9999.
-
-    :param str input_file: input image file path
-    :param list extents: extents for the cropped area
-    :param list geo_trans: An optional GDAL GeoTransform to use instead
-    :param int nodata: The NoData value; defaults to -9999
-
-    :return: clip: cropped part of the image
-    :rtype: ndarray
-    :return: gt2: geotransform parameters for the cropped image
-    :rtype: list
-    """
-
-    def image_to_array(i):
-        """
-        Converts a Python Imaging Library (PIL) array to a gdalnumeric image.
-        """
-        arr = gdalnumeric.frombuffer(i.tobytes(), 'b')
-        arr.shape = i.im.size[1], i.im.size[0]
-        return arr
-
-    raster = gdal.Open(input_file)
-    # Can accept either a gdal.Dataset or numpy.array instance
-    if not isinstance(raster, np.ndarray):
-        if not geo_trans:
-            geo_trans = raster.GetGeoTransform()
-        raster = raster.ReadAsArray()
-    else:
-        if not geo_trans:
-            raise ValueError('geo transform must be supplied')
-
-    # Convert the layer extent to image pixel coordinates
-    min_x, min_y, max_x, max_y = extents
-    ul_x, ul_y = world_to_pixel(geo_trans, min_x, max_y)
-    lr_x, lr_y = world_to_pixel(geo_trans, max_x, min_y)
-
-    # Calculate the pixel size of the new image
-    px_width = int(lr_x - ul_x)
-    px_height = int(lr_y - ul_y)
-
-    # If the clipping features extend out-of-bounds and ABOVE the raster...
-    if geo_trans[3] < max_y:
-        # In such a case... ul_y ends up being negative--can't have that!
-        # iY = ul_y
-        ul_y = 0
-
-    # Multi-band image?
-    try:
-        clip = raster[:, ul_y:lr_y, ul_x:lr_x]
-
-    except IndexError:
-        clip = raster[ul_y:lr_y, ul_x:lr_x]
-
-    # Create a new geomatrix for the image
-    gt2 = list(geo_trans)
-    gt2[0] = min_x
-    gt2[3] = max_y
-
-    # Map points to pixels for drawing the boundary on a blank 8-bit,
-    #   black and white, mask image.
-    points = [(min_x, min_y), (max_x, min_y), (max_x, max_y), (min_y, max_y)]
-    pixels = []
-
-
-    for point in points:
-        pixels.append(world_to_pixel(gt2, point[0], point[1]))
-
-    raster_poly = Image.new('L', size=(px_width, px_height), color=1)
-    rasterize = ImageDraw.Draw(raster_poly)
-    rasterize.polygon(pixels, 0)  # Fill with zeroes
-
-
-    mask = image_to_array(raster_poly)
-
-    # Clip the image using the mask
-    try:
-        clip = gdalnumeric.choose(mask, (clip, nodata))
-
-    # If the clipping features extend out-of-bounds and BELOW the raster...
-    except ValueError:
-        # We have to cut the clipping features to the raster!
-        rshp = list(mask.shape)
-        if mask.shape[-2] != clip.shape[-2]:
-            rshp[0] = clip.shape[-2]
-
-        if mask.shape[-1] != clip.shape[-1]:
-            rshp[1] = clip.shape[-1]
-
-        mask.resize(*rshp, refcheck=False)
-
-        clip = gdalnumeric.choose(mask, (clip, nodata))
-
-    raster = None
-
-    return clip, gt2
 
 
 def resample_nearest_neighbour(input_tif, extents, new_res, output_file):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Cython==0.29.16
 GDAL
-glob2==0.7
 joblib==0.14.1
 mpi4py==3.0.3
 networkx==2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Cython==0.29.16
 GDAL
-Pillow==7.1.1
 glob2==0.7
 joblib==0.14.1
 mpi4py==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Cython==0.29.16
 GDAL
 joblib==0.14.1
 mpi4py==3.0.3

--- a/tests/test_gdal_python.py
+++ b/tests/test_gdal_python.py
@@ -25,28 +25,6 @@ from pyrate.core import gdal_python
 from tests import common
 
 
-class TestCrop(common.UnitTestAdaptation):
-    def test_small_data_cropping(self):
-        small_test_ifgs = common.small_data_setup()
-        # minX, minY, maxX, maxY = extents
-        extents = [150.91, -34.229999976, 150.949166651, -34.17]
-        extents_str = [str(e) for e in extents]
-        cmd = ['gdalwarp', '-overwrite', '-srcnodata', 'None', '-q', '-te'] \
-              + extents_str
-
-        for s in small_test_ifgs:
-            temp_tif = tempfile.mktemp(suffix='.tif')
-            t_cmd = cmd + [s.data_path,  temp_tif]
-            subprocess.check_call(t_cmd)
-            clipped_ref = gdal.Open(temp_tif).ReadAsArray()
-            clipped = gdal_python.crop(s.data_path, extents)[0]
-            np.testing.assert_array_almost_equal(clipped_ref, clipped)
-            try:
-                os.remove(temp_tif)
-            except PermissionError:
-                print("File opened by another process.")
-
-
 class TestResample(common.UnitTestAdaptation):
 
     def test_small_data_resampling(self):
@@ -115,20 +93,6 @@ class TestResample(common.UnitTestAdaptation):
                                                        resampled_temp_tif)
                 self.assertTrue(os.path.exists(resampled_temp_tif))
                 os.remove(resampled_temp_tif)
-
-    def test_small_data_crop_vs_resample(self):
-        small_test_ifgs = common.small_data_setup()
-        # minX, minY, maxX, maxY = extents
-        extents = [150.91, -34.229999976, 150.949166651, -34.17]
-        for s in small_test_ifgs:
-            clipped = gdal_python.crop(s.data_path, extents)[0]
-            resampled_temp_tif = tempfile.mktemp(suffix='.tif',
-                                                prefix='resampled_')
-            resampled = gdal_python.resample_nearest_neighbour(
-                s.data_path, extents, [None, None], resampled_temp_tif)
-            self.assertTrue(os.path.exists(resampled_temp_tif))
-            np.testing.assert_array_almost_equal(resampled[0, :, :], clipped)
-            os.remove(resampled_temp_tif)
 
     def test_resampled_tif_has_metadata(self):
         small_test_ifgs = common.small_data_setup()


### PR DESCRIPTION
`Pillow` is a required python dependency in PyRate but is only used in one function `pyrate.core.gdal_pyrate.crop`, which itself is not used in the main workflow. It is only used as a comparison tool in a unit test.

`glob2` is a requirement but not used anywhere.

I propose we remove these package dependencies and the functions/tests that require them