### PR TITLE
Sb/disable network orbfit and offset user params

### DIFF
--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -112,7 +112,6 @@ orbfitmethod:  2
 orbfitdegrees: 1
 orbfitlksx:    1
 orbfitlksy:    1
-orbfitoffset:  1
 
 #------------------------------------
 # APS spatial low-pass filter parameters

--- a/pyrate/configuration.py
+++ b/pyrate/configuration.py
@@ -219,6 +219,8 @@ class Configuration:
                 else: # i.e. serial
                     self.rows, self.cols = 1, 1
 
+        self.orbfitoffset = 0 if self.orbfitmethod == 1 else 1
+
         # create a temporary directory if not supplied
         if not hasattr(self, 'tmpdir'):
             self.tmpdir = Path(self.outdir).joinpath("tmpdir")

--- a/pyrate/configuration.py
+++ b/pyrate/configuration.py
@@ -219,7 +219,8 @@ class Configuration:
                 else: # i.e. serial
                     self.rows, self.cols = 1, 1
 
-        self.orbfitoffset = 0 if self.orbfitmethod == 1 else 1
+        # force offset = 1 for both method options. This adds the required intercept term to the design matrix
+        self.orbfitoffset = 1
 
         # create a temporary directory if not supplied
         if not hasattr(self, 'tmpdir'):

--- a/pyrate/core/config.py
+++ b/pyrate/core/config.py
@@ -144,6 +144,7 @@ ORBITAL_FIT_DEGREE = 'orbfitdegrees'
 ORBITAL_FIT_LOOKS_X = 'orbfitlksx'
 #: INT; Multi look factor for orbital error calculation in y dimension
 ORBITAL_FIT_LOOKS_Y = 'orbfitlksy'
+#: BOOL (1/0); Add column of offset params to orbit correction design matrix (1: yes, 0: no)
 ORBFIT_OFFSET = 'orbfitoffset'
 
 # Stacking parameters

--- a/pyrate/core/orbital.py
+++ b/pyrate/core/orbital.py
@@ -489,7 +489,7 @@ def orb_fit_calc_wrapper(params: dict) -> None:
         return
 
     if params[cf.ORBITAL_FIT_METHOD] == 2:
-        log.warn("Network orbital correction is currently unsupported. Using independent orbital correction method "
+        log.warning("Network orbital correction is currently unsupported. Using independent orbital correction method "
                  "instead!")
         params[cf.ORBITAL_FIT_METHOD] = 1
 

--- a/pyrate/core/orbital.py
+++ b/pyrate/core/orbital.py
@@ -488,6 +488,11 @@ def orb_fit_calc_wrapper(params: dict) -> None:
         log.info('Orbital correction not required!')
         return
 
+    if params[cf.ORBITAL_FIT_METHOD] == 2:
+        log.warn("Network orbital correction is currently unsupported. Using independent orbital correction method "
+                 "instead!")
+        params[cf.ORBITAL_FIT_METHOD] = 1
+
     ifg_paths = [p.tmp_sampled_path for p in multi_paths]
 
     remove_orbital_error(ifg_paths, params)

--- a/pyrate/default_parameters.py
+++ b/pyrate/default_parameters.py
@@ -261,14 +261,6 @@ PYRATE_DEFAULT_CONFIGURATION = {
         "PossibleValues": [0, 1],
         "Required": False
     },
-    "orbfitoffset": {
-        "DataType": int,
-        "DefaultValue": 1,
-        "MinValue": None,
-        "MaxValue": None,
-        "PossibleValues": [0, 1],
-        "Required": False
-    },
     "orbfitmethod": {
         "DataType": int,
         "DefaultValue": 2,

--- a/tests/test_data/small_test/conf/pyrate_gamma_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_gamma_test.conf
@@ -80,7 +80,6 @@ orbfitmethod:  1
 orbfitdegrees: 1
 orbfitlksx:    1
 orbfitlksy:    1
-orbfitoffset:  1
 
 
 #------------------------------------

--- a/tests/test_data/small_test/conf/pyrate_roipac_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_roipac_test.conf
@@ -88,7 +88,6 @@ orbfitmethod:  1
 orbfitdegrees: 1
 orbfitlksx:    1
 orbfitlksy:    1
-orbfitoffset:  1
 
 #------------------------------------
 # APS correction using spatio-temporal filter

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -54,6 +54,7 @@ def test_vcm_legacy_vs_mpi(mpisync, tempdir, roipac_or_gamma_conf):
     params = configuration.Configuration(output_conf).__dict__
     prepifg.main(params)
     params = configuration.Configuration(output_conf).__dict__
+    params[cf.ORBFIT_OFFSET] = True
     correct._copy_mlooked(params=params)
     correct._update_params_with_tiles(params)
     correct._create_ifg_dict(params=params)


### PR DESCRIPTION
1. remove orbitoffset param and prodide defaults. deafults are `offset=false` for independent method and `offset=true` for network method.
2. use orbfit independent method as fallback until network method is fixed