### PR TITLE
Remove requirement for equal X and Y resolution in conv2tif

### DIFF
--- a/pyrate/core/shared.py
+++ b/pyrate/core/shared.py
@@ -749,8 +749,6 @@ def write_fullres_geotiff(header, data_path, dest, nodata):
     else:
         _check_raw_data(bytes_per_col, data_path, ncols, nrows)
 
-    _check_pixel_res_mismatch(header)
-
     # position and projection data
     gt = [header[ifc.PYRATE_LONG], header[ifc.PYRATE_X_STEP], 0, header[ifc.PYRATE_LAT], 0, header[ifc.PYRATE_Y_STEP]]
     srs = osr.SpatialReference()
@@ -883,18 +881,6 @@ def _check_raw_data(bytes_per_col, data_path, ncols, nrows):
     if act_size != size:
         msg = '%s should have size %s, not %s. Is the correct file being used?'
         raise GeotiffException(msg % (data_path, size, act_size))
-
-
-def _check_pixel_res_mismatch(header):
-    """
-    Convenience function to check equality of pixel resolution in X and Y dimensions
-    """
-    # pylint: disable=invalid-name
-    xs, ys = [abs(i) for i in [header[ifc.PYRATE_X_STEP], header[ifc.PYRATE_Y_STEP]]]
-
-    if xs != ys:
-        msg = 'X and Y cell sizes do not match: %s & %s'
-        raise GeotiffException(msg % (xs, ys))
 
 
 def write_unw_from_data_or_geotiff(geotif_or_data, dest_unw, ifg_proc):

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -156,15 +156,6 @@ class TestGammaToGeoTiff:
         with pytest.raises(GeotiffException):
             write_fullres_geotiff(self.COMBINED, data_path, self.dest, nodata=0)
 
-    def test_mismatching_cell_resolution(self):
-        hdrs = self.DEM_HDR.copy()
-        hdrs[ifc.PYRATE_X_STEP] = 0.1  # fake a mismatch
-        data_path = join(GAMMA_TEST_DIR, '16x20_20090713-20090817_VV_4rlks_utm.unw')
-        self.dest = os.path.join(TEMPDIR, 'fake')
-
-        with pytest.raises(GeotiffException):
-            write_fullres_geotiff(hdrs, data_path, self.dest, 0)
-
     def compare_rasters(self, ds, exp_ds):
         band = ds.GetRasterBand(1)
         exp_band = exp_ds.GetRasterBand(1)

--- a/tests/test_roipac.py
+++ b/tests/test_roipac.py
@@ -135,15 +135,6 @@ class TestRoipacToGeoTiff(UnitTestAdaptation):
         data_path = join(PREP_TEST_OBS, 'geo_060619-061002.unw')
         self.assertRaises(GeotiffException, write_fullres_geotiff, hdrs, data_path, self.dest, 0)
 
-    def test_mismatching_cell_resolution(self):
-        hdrs = self.HDRS.copy()
-        hdrs[ifc.PYRATE_X_STEP] = 0.1 # fake a mismatch
-        hdrs[ifc.PYRATE_DATUM] = 'WGS84'
-        data_path = join(PREP_TEST_OBS, 'geo_060619-061002.unw')
-        self.dest = os.path.join(TEMPDIR, 'fake')
-
-        self.assertRaises(GeotiffException, write_fullres_geotiff, hdrs, data_path, self.dest, 0)
-
     def compare_rasters(self, ds, exp_ds):
         band = ds.GetRasterBand(1)
         exp_band = exp_ds.GetRasterBand(1)


### PR DESCRIPTION
This PR removes a long-held rule in `conv2tif` that the input rasters must have equal X and Y pixel resolutions.

This issue was identified by an external user who has unequal X/Y resolution images - see https://github.com/GeoscienceAustralia/PyRate/issues/305

In this PR I have removed:

- one check in the function `shared.write_fullres_geotiff`, used only in `conv2tif` step
- the check function associated with the above
- two tests associated with the check function