### PR TITLE
Add switch to specify uncertainty communication in rate/velocity error maps

### DIFF
--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -22,6 +22,12 @@ savenpy:       0
 savetsincr:    0
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# Integer parameters
+
+# Number of sigma to report velocity error. 1 or 2. Default: 2 (TIMESERIES/MERGE)
+velerror_nsig: 2
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Multi-threading parameters used by correct/stacking/timeseries
 # gamma prepifg runs in parallel on a single machine if parallel = 1
 # parallel: 1 = parallel, 0 = serial

--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -24,7 +24,7 @@ savetsincr:    0
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Integer parameters
 
-# Number of sigma to report velocity error. 1 or 2. Default: 2 (TIMESERIES/STACK)
+# Number of sigma to report velocity error. Positive integer. Default: 2 (TIMESERIES/STACK)
 velerror_nsig: 2
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -24,7 +24,7 @@ savetsincr:    0
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Integer parameters
 
-# Number of sigma to report velocity error. 1 or 2. Default: 2 (TIMESERIES/MERGE)
+# Number of sigma to report velocity error. 1 or 2. Default: 2 (TIMESERIES/STACK)
 velerror_nsig: 2
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/pyrate/core/stack.py
+++ b/pyrate/core/stack.py
@@ -57,8 +57,7 @@ def stack_rate_array(ifgs, params, vcmt, mst=None):
         for j in range(cols):
             rate[i, j], error[i, j], samples[i, j] = stack_rate_pixel(obs[:, i, j], mst[:, i, j], vcmt, span, nsig, pthresh)
 
-    return rate, error, samples
-
+    return rate, params["velerror_nsig"]*error, samples
 
 def mask_rate(rate, error, maxsig):
     """

--- a/pyrate/core/timeseries.py
+++ b/pyrate/core/timeseries.py
@@ -376,7 +376,7 @@ def linear_rate_array(tscuml, ifgs, params):
             linrate[i, j], intercept[i, j], rsquared[i, j], error[i, j], samples[i, j] = \
                 linear_rate_pixel(tscuml[i, j, :], t)
 
-    return linrate, intercept, rsquared, error, samples
+    return linrate, intercept, rsquared, params["velerror_nsig"]*error, samples
 
 
 def _missing_option_error(option):

--- a/pyrate/default_parameters.py
+++ b/pyrate/default_parameters.py
@@ -513,8 +513,8 @@ PYRATE_DEFAULT_CONFIGURATION = {
         "DataType": int,
         "DefaultValue": 2,
         "MinValue": 1,
-        "MaxValue": 2,
-        "PossibleValues": [1, 2],
+        "MaxValue": None,
+        "PossibleValues": None,
         "Required": False
     },
     "correct": {

--- a/pyrate/default_parameters.py
+++ b/pyrate/default_parameters.py
@@ -509,6 +509,14 @@ PYRATE_DEFAULT_CONFIGURATION = {
         "PossibleValues": [1, 0],
         "Required": False
     },
+    "velerror_nsig": {
+        "DataType": int,
+        "DefaultValue": 2,
+        "MinValue": 1,
+        "MaxValue": 2,
+        "PossibleValues": [1, 2],
+        "Required": False
+    },
     "correct": {
         "DataType": list,
         "DefaultValue": ['orbfit', 'refphase', 'demerror', 'mst', 'apscorrect', 'maxvar', 'timeseries', 'stack'],

--- a/tests/test_data/small_test/conf/pyrate_roipac_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_roipac_test.conf
@@ -34,6 +34,8 @@ noDataValue:  0.0
 # Nan conversion flag. Set to 1 if missing (0) phase values are converted to nan
 nan_conversion: 1
 
+# number of sigma for rate uncertainty/error maps
+velerror_nsig: 1
 
 #-----------------------------------
 # Multi-threading parameters: used by stacking/timeseries/gamma prepifg

--- a/tests/test_stackrate.py
+++ b/tests/test_stackrate.py
@@ -38,7 +38,6 @@ from pyrate.configuration import Configuration
 from tests import common
 from tests.common import SML_TEST_DIR, prepare_ifgs_without_phase, pre_prepare_ifgs
 
-
 def default_params():
     return {'pthr': 3, 'nsig': 3, 'maxsig': 2, 'parallel': 1, 'processes': 8}
 
@@ -114,6 +113,8 @@ class TestLegacyEquality:
         params = Configuration(common.TEST_CONF_ROIPAC).__dict__
         params[pyrate.constants.TEMP_MLOOKED_DIR] = os.path.join(params[pyrate.constants.OUT_DIR],
                                                                  pyrate.constants.TEMP_MLOOKED_DIR)
+        # force error maps to 1-sigma to match legacy
+        params["velerror_nsig"] = 1
         conv2tif.main(params)
         prepifg.main(params)
 
@@ -202,7 +203,7 @@ class TestLegacyEquality:
 
     def test_stackrate_error(self):
         """
-        Compare with legacy data
+        Compare with legacy data. Default behaviour is now 2-sigma, so mult legacy by 2.
         """
         assert_array_almost_equal(self.error_s, self.error_container, decimal=3)
 

--- a/tests/test_stackrate.py
+++ b/tests/test_stackrate.py
@@ -203,7 +203,7 @@ class TestLegacyEquality:
 
     def test_stackrate_error(self):
         """
-        Compare with legacy data. Default behaviour is now 2-sigma, so mult legacy by 2.
+        Compare with legacy data.
         """
         assert_array_almost_equal(self.error_s, self.error_container, decimal=3)
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -19,6 +19,7 @@ This Python module contains tests for the timeseries.py PyRate module.
 """
 import os
 import shutil
+from copy import deepcopy
 import pytest
 from datetime import date, timedelta
 from numpy import nan, asarray, where, array
@@ -399,6 +400,18 @@ class TestLinearRateArray:
         assert_array_almost_equal(self.rsq, r, 1e-20)
         assert_array_almost_equal(self.error, e, 1e-20)
         assert_array_almost_equal(self.samp, s, 1e-20)
+
+    def test_linear_rate_array_two_sigma(self):
+        """
+        Check that the "nsigma" switch in the config dictionary
+        actually results in a change in the error map.
+        """
+        # make a deep copy of the params dict to avoid changing
+        # state for other tests if this one fails
+        params = deepcopy(self.params)
+        params["velerror_nsig"] = 2
+        _, _, _, e, _ = linear_rate_array(self.tscuml, self.ifgs, params)
+        assert_array_almost_equal(self.error*2, e, 1e-20)
 
     def test_linear_rate_array_exception(self):
         # depth of tscuml should equal nepochs


### PR DESCRIPTION
1. I have added a switch to the config file, which allows the user to specify whether they would like the velocity error maps to represent 1- or 2-sigma errors. This switch applies to the error maps produced by both `stack` and `timeseries` methods. The default is 2-sigma (95% confidence interval) because this is the standard for uncertainty communication in many fields of science.
2. I modified the test suite, specifically `test_timeseries.py` and `test_stackrate.py`, to manually specify 1-sigma errors in the default parameters dictionary. This is for compatibility with the legacy test datasets which have 1-sigma error maps.
3. I added a new test to `test_timeseries.py` which confirms that the switch actually produces a 2-sigma error map when this is specified.