### PR TITLE
signal polarity configuration implemented and tested

### DIFF
--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -1,7 +1,7 @@
 # PyRate configuration file for GAMMA-format interferograms
 #
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# Optional ON/OFF switches - ON = 1; OFF = 0
+# Optional Correction ON/OFF switches - ON = 1; OFF = 0
 
 # Coherence masking (PREPIFG)
 cohmask:       0
@@ -16,29 +16,33 @@ demerror:      1
 phase_closure: 0
 
 # APS correction using spatio-temporal filter (CORRECT)
-apsest:        1
-
-# Optional save of numpy array files for output products (MERGE)
-savenpy:       0
-
-# Optional save of incremental time series products (TIMESERIES/MERGE)
-savetsincr:    0
+apsest:        0
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Integer parameters
 
-# LOS Projection of output products converts slanted (native) LOS signals
-# to either "pseudo-vertical" or "pseudo-horizontal", by dividing by the
-# cosine or sine of the incidence angle for each pixel, respectively.
+# LOS Projection of output products (MERGE)
+# Converts slanted (native) LOS signals to either "pseudo-vertical" or "pseudo-horizontal", 
+# by dividing by the cosine or sine of the incidence angle for each pixel, respectively.
 # los_projection: 0 = LOS (no conversion); 1 = pseudo-vertical; 2 = pseudo-horizontal.
-los_projection: 0
+los_projection:  0
+
+# Sign convention for phase data (MERGE)
+# signal_polarity:  1 = retain sign convention of input interferograms
+# signal_polarity: -1 = reverse sign convention of input interferograms (default)
+signal_polarity: -1
 
 # Number of sigma to report velocity error. Positive integer. Default: 2 (TIMESERIES/STACK)
-velerror_nsig: 2
+velerror_nsig:   2
+
+# Optional save of numpy array files for output products (MERGE)
+savenpy:         0
+
+# Optional save of incremental time series products (TIMESERIES/MERGE)
+savetsincr:      0
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-# Multi-threading parameters used by correct/stacking/timeseries
-# gamma prepifg runs in parallel on a single machine if parallel = 1
+# Multi-threading parameters (CORRECT/TIMESERIES/STACK)
 # parallel: 1 = parallel, 0 = serial
 parallel:      0
 # number of processes
@@ -102,13 +106,6 @@ noDataValue:   0.0
 
 # Nan conversion flag. Set to 1 if missing No-data values are to be converted to NaN
 nan_conversion: 1
-
-
-# sign convention for phase data
-# signal_polarity = -1 for motion away from the radar (subsidence) as negative
-# signal_polarity = 1 for motion away from the radar (uplift) as positive
-signal_polarity: -1
-
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # CORRECT parameters

--- a/input_parameters.conf
+++ b/input_parameters.conf
@@ -103,6 +103,13 @@ noDataValue:   0.0
 # Nan conversion flag. Set to 1 if missing No-data values are to be converted to NaN
 nan_conversion: 1
 
+
+# sign convention for phase data
+# signal_polarity = -1 for motion away from the radar (subsidence) as negative
+# signal_polarity = 1 for motion away from the radar (uplift) as positive
+signal_polarity: -1
+
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # CORRECT parameters
 #------------------------------------

--- a/pyrate/configuration.py
+++ b/pyrate/configuration.py
@@ -65,7 +65,7 @@ def validate_parameter_value(input_name, input_value, min_value=None, max_value=
         if input_value not in possible_values:  # pragma: no cover
             raise ValueError(
                 "Invalid value for " + str(input_name) + " supplied: " + str(
-                    input_value) + ". Provide a value from: " + str(possible_values) + ".")
+                    input_value) + ". Provide one of these values: " + str(possible_values) + ".")
     return True
 
 

--- a/pyrate/constants.py
+++ b/pyrate/constants.py
@@ -130,6 +130,9 @@ IFG_YFIRST = 'ifgyfirst'
 #: FLOAT; Maximum latitude for cropping with method 3
 IFG_YLAST = 'ifgylast'
 
+# sign convention for phase data
+SIGNAL_POLARITY = 'signal_polarity'
+
 # reference pixel parameters
 #: INT; Longitude (decimal degrees) of reference pixel, or if left blank a search will be performed
 REFX = 'refx'

--- a/pyrate/constants.py
+++ b/pyrate/constants.py
@@ -130,9 +130,6 @@ IFG_YFIRST = 'ifgyfirst'
 #: FLOAT; Maximum latitude for cropping with method 3
 IFG_YLAST = 'ifgylast'
 
-# sign convention for phase data
-SIGNAL_POLARITY = 'signal_polarity'
-
 # reference pixel parameters
 #: INT; Longitude (decimal degrees) of reference pixel, or if left blank a search will be performed
 REFX = 'refx'
@@ -274,10 +271,11 @@ ORB_DEGREE_NAMES = {PLANAR: 'PLANAR',
                     QUADRATIC: 'QUADRATIC',
                     PART_CUBIC: 'PART CUBIC'}
 
-
 # geometry outputs
 GEOMETRY_OUTPUT_TYPES = ['rdc_azimuth', 'rdc_range', 'look_angle', 'incidence_angle', 'azimuth_angle', 'range_dist']
 
+# sign convention for phase data
+SIGNAL_POLARITY = 'signal_polarity'
 
 # LOS projection
 LOS_PROJECTION = 'los_projection'

--- a/pyrate/constants.py
+++ b/pyrate/constants.py
@@ -280,6 +280,9 @@ SIGNAL_POLARITY = 'signal_polarity'
 # LOS projection
 LOS_PROJECTION = 'los_projection'
 
+# Number of sigma to report velocity error
+VELERROR_NSIG = 'velerror_nsig'
+
 # dir for temp files
 TMPDIR = 'tmpdir'
 

--- a/pyrate/core/shared.py
+++ b/pyrate/core/shared.py
@@ -1078,7 +1078,7 @@ def write_output_geotiff(md, gt, wkt, data, dest, nodata):
     # set other metadata
     for k in [ifc.SEQUENCE_POSITION, ifc.PYRATE_REFPIX_X, ifc.PYRATE_REFPIX_Y, ifc.PYRATE_REFPIX_LAT,
               ifc.PYRATE_REFPIX_LON, ifc.PYRATE_MEAN_REF_AREA, ifc.PYRATE_STDDEV_REF_AREA,
-              ifc.EPOCH_DATE, C.LOS_PROJECTION.upper()]:
+              ifc.EPOCH_DATE, C.LOS_PROJECTION.upper(), C.SIGNAL_POLARITY.upper()]:
         if k in md:
             ds.SetMetadataItem(k, str(md[k]))
 

--- a/pyrate/core/shared.py
+++ b/pyrate/core/shared.py
@@ -1078,7 +1078,8 @@ def write_output_geotiff(md, gt, wkt, data, dest, nodata):
     # set other metadata
     for k in [ifc.SEQUENCE_POSITION, ifc.PYRATE_REFPIX_X, ifc.PYRATE_REFPIX_Y, ifc.PYRATE_REFPIX_LAT,
               ifc.PYRATE_REFPIX_LON, ifc.PYRATE_MEAN_REF_AREA, ifc.PYRATE_STDDEV_REF_AREA,
-              ifc.EPOCH_DATE, C.LOS_PROJECTION.upper(), C.SIGNAL_POLARITY.upper()]:
+              ifc.EPOCH_DATE, C.LOS_PROJECTION.upper(), C.SIGNAL_POLARITY.upper(),
+              C.VELERROR_NSIG.upper()]:
         if k in md:
             ds.SetMetadataItem(k, str(md[k]))
 

--- a/pyrate/core/stack.py
+++ b/pyrate/core/stack.py
@@ -57,7 +57,7 @@ def stack_rate_array(ifgs, params, vcmt, mst=None):
         for j in range(cols):
             rate[i, j], error[i, j], samples[i, j] = stack_rate_pixel(obs[:, i, j], mst[:, i, j], vcmt, span, nsig, pthresh)
 
-    return rate, params["velerror_nsig"]*error, samples
+    return rate, params[C.VELERROR_NSIG]*error, samples
 
 def mask_rate(rate, error, maxsig):
     """
@@ -73,7 +73,6 @@ def mask_rate(rate, error, maxsig):
     :return: error: Masked error (standard deviation) map
     :rtype: ndarray
     """
-    log.info('Masking stack rate and error maps where sigma is greater than {} millimetres'.format(maxsig))
     # initialise mask array with existing NaNs
     mask = ~isnan(error)
     # original Nan count

--- a/pyrate/core/timeseries.py
+++ b/pyrate/core/timeseries.py
@@ -376,7 +376,7 @@ def linear_rate_array(tscuml, ifgs, params):
             linrate[i, j], intercept[i, j], rsquared[i, j], error[i, j], samples[i, j] = \
                 linear_rate_pixel(tscuml[i, j, :], t)
 
-    return linrate, intercept, rsquared, params["velerror_nsig"]*error, samples
+    return linrate, intercept, rsquared, params[C.VELERROR_NSIG]*error, samples
 
 
 def _missing_option_error(option):

--- a/pyrate/default_parameters.py
+++ b/pyrate/default_parameters.py
@@ -517,6 +517,14 @@ PYRATE_DEFAULT_CONFIGURATION = {
         "PossibleValues": [2, 1, 0],
         "Required": False
     },
+    "signal_polarity": {
+        "DataType": int,
+        "DefaultValue": -1,
+        "MinValue": -1,
+        "MaxValue": 1,
+        "PossibleValues": [1, -1],
+        "Required": False
+    },
     "velerror_nsig": {
         "DataType": int,
         "DefaultValue": 2,

--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -310,7 +310,7 @@ def __save_merged_files(ifgs_dict, params, array, out_type, index=None, savenpy=
                          f"{ifc.LOS_PROJECTION_OPTION[params[C.LOS_PROJECTION]]} for file {dest}")
             incidence = shared.Geometry(incidence_path)
             incidence.open()
-            array /= los_projection_divisors[params[C.LOS_PROJECTION]](incidence.data)
+            array /= los_projection_divisors[params[C.LOS_PROJECTION]](incidence.data) * params[C.SIGNAL_POLARITY]
             md[C.LOS_PROJECTION.upper()] = ifc.LOS_PROJECTION_OPTION[params[C.LOS_PROJECTION]]
 
     shared.write_output_geotiff(md, gt, wkt, array, dest, np.nan)

--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -39,6 +39,13 @@ def main(params: dict) -> None:
     PyRate merge main function. Assembles product tiles in to
     single geotiff files
     """
+    if params[C.SIGNAL_POLARITY] == 1:
+        log.info(f"Saving output products with the same sign convention as input data")
+    elif params[C.SIGNAL_POLARITY] == -1:
+        log.info(f"Saving output products with reversed sign convention compared to the input data")
+    else:
+        log.warning(f"Check the value of signal_polarity parameter")
+
     out_types = []
     stfile = join(params[C.TMPDIR], 'stack_rate_0.npy')
     if exists(stfile):

--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -307,7 +307,7 @@ def __save_merged_files(ifgs_dict, params, array, out_type, index=None, savenpy=
 
     md[ifc.DATA_TYPE] = out_type_md_dict[out_type]
 
-    if out_type in los_projection_out_types:  # apply LOS projection for these outputs
+    if out_type in los_projection_out_types:  # apply LOS projection and sign conversion for these outputs
         incidence_path = Path(Configuration.geometry_files(params)['incidence_angle'])
         if incidence_path.exists():  # We can do LOS projection
             if params[C.LOS_PROJECTION] == ifc.LINE_OF_SIGHT:
@@ -319,10 +319,15 @@ def __save_merged_files(ifgs_dict, params, array, out_type, index=None, savenpy=
             incidence.open()
             array /= los_projection_divisors[params[C.LOS_PROJECTION]](incidence.data) * params[C.SIGNAL_POLARITY]
             md[C.LOS_PROJECTION.upper()] = ifc.LOS_PROJECTION_OPTION[params[C.LOS_PROJECTION]]
+            md[C.SIGNAL_POLARITY.upper()] = params[C.SIGNAL_POLARITY]
 
     shared.write_output_geotiff(md, gt, wkt, array, dest, np.nan)
-    if C.LOS_PROJECTION.upper() in md:   # clear the extra metadata so it does not mess up other images
+    # clear the extra metadata so it does not mess up other images
+    if C.LOS_PROJECTION.upper() in md:
         md.pop(C.LOS_PROJECTION.upper())
+    if C.SIGNAL_POLARITY.upper() in md:
+        md.pop(C.SIGNAL_POLARITY.upper())
+
     if savenpy:
         np.save(file=npy_file, arr=array)
 

--- a/tests/test_data/cropA/pyrate_mexico_cropa.conf
+++ b/tests/test_data/cropA/pyrate_mexico_cropa.conf
@@ -91,6 +91,12 @@ noDataValue:   0.0
 # Nan conversion flag. Set to 1 if missing No-data values are to be converted to NaN
 nan_conversion: 1
 
+# sign convention for phase data
+# signal_polarity = -1 for motion away from the radar (subsidence) as negative
+# signal_polarity = 1 for motion away from the radar (uplift) as positive
+signal_polarity: -1
+
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # CORRECT parameters
 #------------------------------------

--- a/tests/test_data/cropA/pyrate_mexico_cropa.conf
+++ b/tests/test_data/cropA/pyrate_mexico_cropa.conf
@@ -92,8 +92,6 @@ noDataValue:   0.0
 nan_conversion: 1
 
 # sign convention for phase data
-# signal_polarity = -1 for motion away from the radar (subsidence) as negative
-# signal_polarity = 1 for motion away from the radar (uplift) as positive
 signal_polarity: -1
 
 

--- a/tests/test_data/small_test/conf/pyrate_gamma_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_gamma_test.conf
@@ -63,8 +63,6 @@ ifgyfirst:    -34.18
 ifgylast:     -34.22
 
 # sign convention for phase data
-# signal_polarity = -1 for motion away from the radar (subsidence) as negative
-# signal_polarity = 1 for motion away from the radar (uplift) as positive
 signal_polarity: -1
 
 

--- a/tests/test_data/small_test/conf/pyrate_gamma_test.conf
+++ b/tests/test_data/small_test/conf/pyrate_gamma_test.conf
@@ -62,6 +62,12 @@ ifgxlast:     150.94
 ifgyfirst:    -34.18
 ifgylast:     -34.22
 
+# sign convention for phase data
+# signal_polarity = -1 for motion away from the radar (subsidence) as negative
+# signal_polarity = 1 for motion away from the radar (uplift) as positive
+signal_polarity: -1
+
+
 #------------------------------------
 # Reference pixel search options
 # refx/y: coordinate of reference pixel. If <= 0 then search for pixel will be performed

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -71,7 +71,7 @@ def test_los_conversion_divisors():
 
 @pytest.mark.mpi
 @pytest.mark.slow
-# @pytest.mark.skipif(not PY37GDAL302, reason="Only run in one CI env")
+@pytest.mark.skipif(not PY37GDAL302, reason="Only run in one CI env")
 class TestLOSConversion:
     @classmethod
     def setup_class(cls):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -120,14 +120,14 @@ class TestLOSConversion:
         los_proj_dir = all_dirs[ifc.LINE_OF_SIGHT]
         pseudo_ver = all_dirs[ifc.PSEUDO_VERTICAL]
         pseudo_hor = all_dirs[ifc.PSEUDO_HORIZONTAL]
-        signal_polarity_reverserd_pseudo_hor = all_dirs[C.SIGNAL_POLARITY]
+        signal_polarity_reversed_pseudo_hor = all_dirs[C.SIGNAL_POLARITY]
 
         assert len(list(los_proj_dir.glob('*.tif'))) == 26  # 12 tsincr, 12 tscuml + 1 stack rate + 1 linear rate
         for tif in los_proj_dir.glob('*.tif'):
             ds = DEM(tif)
             ds_ver = DEM(pseudo_ver.joinpath(tif.name))
             ds_hor = DEM(pseudo_hor.joinpath(tif.name))
-            ds_hor_sig = DEM(signal_polarity_reverserd_pseudo_hor.joinpath(tif.name))
+            ds_hor_sig = DEM(signal_polarity_reversed_pseudo_hor.joinpath(tif.name))
             ds.open()
             ds_ver.open()
             ds_hor.open()
@@ -144,13 +144,14 @@ class TestLOSConversion:
             ds_ver_md = ds_ver.dataset.GetMetadata()
             assert ds_ver_md.pop(C.LOS_PROJECTION.upper()) == ifc.LOS_PROJECTION_OPTION[ifc.PSEUDO_VERTICAL]
             assert ds_md == ds_ver_md
+            assert ds_md.pop(C.SIGNAL_POLARITY.upper()) == '-1'
             ds_hor_md = ds_hor.dataset.GetMetadata()
             ds_hor_sig_md = ds_hor_sig.dataset.GetMetadata()
+            assert ds_hor_sig_md.pop(C.SIGNAL_POLARITY.upper()) != ds_hor_md.pop(C.SIGNAL_POLARITY.upper())
             assert ds_hor_sig_md == ds_hor_md
             assert ds_hor_md.pop(C.LOS_PROJECTION.upper()) == ifc.LOS_PROJECTION_OPTION[ifc.PSEUDO_HORIZONTAL]
-            assert ds_md == ds_hor_md
-            ds_hor_sig_md = ds_hor_sig.dataset.GetMetadata()
             assert ds_hor_sig_md.pop(C.LOS_PROJECTION.upper()) == ifc.LOS_PROJECTION_OPTION[ifc.PSEUDO_HORIZONTAL]
+            assert ds_md == ds_hor_md
             assert ds_md == ds_hor_sig_md
 
     def run_with_new_params(self, k_dir, params):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -110,7 +110,7 @@ class TestLOSConversion:
             all_dirs[k] = k_dir
             self.run_with_new_params(k_dir, params)
 
-        signal_dir = Path(params[C.OUT_DIR]).joinpath('signal_polatiry_dir')
+        signal_dir = Path(params[C.OUT_DIR]).joinpath('signal_polarity_dir')
         signal_dir.mkdir(exist_ok=True)
         all_dirs[C.SIGNAL_POLARITY] = signal_dir
 

--- a/tests/test_stackrate.py
+++ b/tests/test_stackrate.py
@@ -114,7 +114,7 @@ class TestLegacyEquality:
         params[C.TEMP_MLOOKED_DIR] = os.path.join(params[C.OUT_DIR], C.TEMP_MLOOKED_DIR)
 
         # force error maps to 1-sigma to match legacy
-        params["velerror_nsig"] = 1
+        params[C.VELERROR_NSIG] = 1
         conv2tif.main(params)
         prepifg.main(params)
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -409,7 +409,7 @@ class TestLinearRateArray:
         # make a deep copy of the params dict to avoid changing
         # state for other tests if this one fails
         params = deepcopy(self.params)
-        params["velerror_nsig"] = 2
+        params[C.VELERROR_NSIG] = 2
         _, _, _, e, _ = linear_rate_array(self.tscuml, self.ifgs, params)
         assert_array_almost_equal(self.error*2, e, 1e-20)
 


### PR DESCRIPTION
@mcgarth edit:
This PR implements a simple signal polarity conversion, which is applied to output geotiff products generated during the MERGE step. Data sign is not affected in the other processing steps. Default is multiplying the output data arrays by -1. This ensures GA's standard input interferograms are converted such that PyRate outputs have range increases as negative and range decreases as positive.
- Metadata for `signal_polarity` and `velerror_nsig` has been added to the geotiffs
- Info messages have been added to MERGE step to report on conversions being applied