### PR TITLE
Add support for GAMMA initial baseline estimates

### DIFF
--- a/pyrate/core/gamma.py
+++ b/pyrate/core/gamma.py
@@ -233,42 +233,39 @@ def parse_baseline_header(path: str) -> dict:
     Will read the Precise baseline estimate, if available,
     otherwise will read the Initial baseline estimate.
 
-    :param path: `Full path to Gamma *base.par file`
+    :param path: Full path to Gamma *base.par file
 
     :return: bdict: Dictionary of baseline values
     """
-    lookup = _parse_header(path)
+    lookup = _parse_header(path)  # read file contents in to a dict
+
+    # split the initial and precise baselines
+    initial = lookup[GAMMA_INITIAL_BASELINE]
+    initial_rate = lookup[GAMMA_INITIAL_BASELINE_RATE]
+    precise = lookup[GAMMA_PRECISION_BASELINE]
+    precise_rate = lookup[GAMMA_PRECISION_BASELINE_RATE]
+
+    # read the precise baseline if all components are non-zero
+    # otherwise read the initial baseline
+    if float(precise[0]) == 0.0 and float(precise[1]) == 0.0 and float(precise[2]) == 0.0:
+        log.debug('Reading Initial GAMMA baseline values')
+        baseline, baseline_rate = initial, initial_rate
+    else:
+        log.debug('Reading Precise GAMMA baseline values')
+        baseline, baseline_rate = precise, precise_rate
+
+    # Extract and return a dict of baseline values
+    bdict = {}
 
     # baseline vector (along Track, aCross track, Normal to the track)
-    initial_tcn = lookup[GAMMA_INITIAL_BASELINE]
-    initial_rate_tcn = lookup[GAMMA_INITIAL_BASELINE_RATE]
-    precise_tcn = lookup[GAMMA_PRECISION_BASELINE]
-    precise_rate_tcn = lookup[GAMMA_PRECISION_BASELINE_RATE]
-    
-    if float(precise_tcn[0]) == 0.0 and float(precise_tcn[1]) == 0.0 and float(precise_tcn[2]) == 0.0:
-        bdict = __extract_baseline_vals(initial_tcn, initial_rate_tcn)
-        log.debug('Reading Initial GAMMA baseline values')
-    else:
-        bdict = __extract_baseline_vals(precise_tcn, precise_rate_tcn)
-        log.debug('Reading Precise GAMMA baseline values')
-
-    print(bdict)
+    bdict[ifc.PYRATE_BASELINE_T] = float(baseline[0])
+    bdict[ifc.PYRATE_BASELINE_C] = float(baseline[1])
+    bdict[ifc.PYRATE_BASELINE_N] = float(baseline[2])
+    bdict[ifc.PYRATE_BASELINE_RATE_T] = float(baseline_rate[0])
+    bdict[ifc.PYRATE_BASELINE_RATE_C] = float(baseline_rate[1])
+    bdict[ifc.PYRATE_BASELINE_RATE_N] = float(baseline_rate[2])
 
     return bdict
-
-
-def __extract_baseline_vals(baseline, baseline_rate):
-    """Extract and return a dict of baseline vals"""
-    vals = {}
-
-    vals[ifc.PYRATE_BASELINE_T] = float(baseline[0])
-    vals[ifc.PYRATE_BASELINE_C] = float(baseline[1])
-    vals[ifc.PYRATE_BASELINE_N] = float(baseline[2])
-    vals[ifc.PYRATE_BASELINE_RATE_T] = float(baseline_rate[0])
-    vals[ifc.PYRATE_BASELINE_RATE_C] = float(baseline_rate[1])
-    vals[ifc.PYRATE_BASELINE_RATE_N] = float(baseline_rate[2])
-
-    return vals
 
 
 def _frequency_to_wavelength(freq):

--- a/pyrate/core/gamma.py
+++ b/pyrate/core/gamma.py
@@ -245,8 +245,8 @@ def parse_baseline_header(path: str) -> dict:
     precise = lookup[GAMMA_PRECISION_BASELINE]
     precise_rate = lookup[GAMMA_PRECISION_BASELINE_RATE]
 
-    # read the precise baseline if all components are non-zero
-    # otherwise read the initial baseline
+    # read the initial baseline if all precise components are zero
+    # (indicates that the precise baseline estimation was not ran in GAMMA workflow)
     if float(precise[0]) == 0.0 and float(precise[1]) == 0.0 and float(precise[2]) == 0.0:
         log.debug('Reading Initial GAMMA baseline values')
         baseline, baseline_rate = initial, initial_rate

--- a/tests/test_data/gamma/20090713-20090817_base.par
+++ b/tests/test_data/gamma/20090713-20090817_base.par
@@ -1,6 +1,0 @@
-initial_baseline(TCN):          0.1585592       15.3525463        9.7718029   m   m   m
-initial_baseline_rate:          0.0000000       -0.0439410        0.0177195   m/s m/s m/s
-precision_baseline(TCN):        0.1585592       15.3525463        9.7718029   m   m   m
-precision_baseline_rate:        0.0000000       -0.0439410        0.0177195   m/s m/s m/s
-unwrap_phase_constant:            0.00000     radians
-

--- a/tests/test_data/gamma/20160114-20160126_base.par
+++ b/tests/test_data/gamma/20160114-20160126_base.par
@@ -1,0 +1,6 @@
+initial_baseline(TCN):         -0.0000026     -103.7427072        2.8130731   m   m   m
+initial_baseline_rate:          0.0000000       -0.0173538       -0.0055098   m/s m/s m/s
+precision_baseline(TCN):        0.0000000     -103.8364725        2.8055662   m   m   m
+precision_baseline_rate:        0.0000000       -0.0182215       -0.0065402   m/s m/s m/s
+unwrap_phase_constant:           -0.00027     radians
+

--- a/tests/test_data/gamma/20160114-20160126_base_init.par
+++ b/tests/test_data/gamma/20160114-20160126_base_init.par
@@ -1,0 +1,6 @@
+initial_baseline(TCN):          0.6529765     -103.9065694        2.9253896   m   m   m
+initial_baseline_rate:          0.0000000       -0.0231786       -0.0038703   m/s m/s m/s
+precision_baseline(TCN):        0.0000000        0.0000000        0.0000000   m   m   m
+precision_baseline_rate:        0.0000000        0.0000000        0.0000000   m/s m/s m/s
+unwrap_phase_constant:            0.00000     radians
+

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -92,7 +92,7 @@ class TestGammaToGeoTiff:
         hdr_paths = [join(GAMMA_TEST_DIR, f) for f in filenames]
         hdrs = [gamma.parse_epoch_header(p) for p in hdr_paths]
         dem_hdr_path = join(GAMMA_TEST_DIR, 'dem16x20raw.dem.par')
-        base_hdr_path = join(GAMMA_TEST_DIR, '20090713-20090817_base.par')
+        base_hdr_path = join(GAMMA_TEST_DIR, '20160114-20160126_base.par')
         cls.DEM_HDR = gamma.parse_dem_header(dem_hdr_path)
         cls.BASE_HDR = gamma.parse_baseline_header(base_hdr_path)
         cls.COMBINED = gamma.combine_headers(*hdrs, dem_hdr=cls.DEM_HDR, base_hdr=cls.BASE_HDR)
@@ -245,7 +245,7 @@ class TestHeaderCombination:
         self.err = gamma.GammaException
         dem_hdr_path = join(GAMMA_TEST_DIR, 'dem16x20raw.dem.par')
         self.dh = gamma.parse_dem_header(dem_hdr_path)
-        base_hdr_path = join(GAMMA_TEST_DIR, '20090713-20090817_base.par')
+        base_hdr_path = join(GAMMA_TEST_DIR, '20160114-20160126_base.par')
         self.bh = gamma.parse_baseline_header(base_hdr_path)
 
     @staticmethod
@@ -363,3 +363,57 @@ def test_meta_data_exists(series_ifgs, parallel_ifgs):
         assert (s.meta_data[ifc.DATA_TYPE] == ifc.MULTILOOKED) or \
                (s.meta_data[ifc.DATA_TYPE] == ifc.MULTILOOKED_COH)
     assert i + 1 == 34
+
+
+class TestGammaBaselineRead:
+    """Tests the reading of initial and precise baselines"""
+
+    def setup_method(self):
+        self.init = join(GAMMA_TEST_DIR, '20160114-20160126_base_init.par')
+        self.prec = join(GAMMA_TEST_DIR, '20160114-20160126_base.par')
+
+
+    def test_prec_baseline_read(self):
+        """Test that the Precise baseline values are being read"""
+        exp_i = {'BASELINE_T': -0.0000026, 'BASELINE_C': -103.7427072,
+                 'BASELINE_N': 2.8130731, 'BASELINE_RATE_T': 0.0,
+                 'BASELINE_RATE_C': -0.0173538,
+                 'BASELINE_RATE_N': -0.0055098}
+
+        exp_p = {'BASELINE_T': 0.0, 'BASELINE_C': -103.8364725,
+                 'BASELINE_N': 2.8055662, 'BASELINE_RATE_T': 0.0,
+                 'BASELINE_RATE_C': -0.0182215,
+                 'BASELINE_RATE_N': -0.0065402}
+
+        prec = gamma.parse_baseline_header(self.prec)
+        # Precise values are read
+        assert prec != exp_i
+        assert prec == exp_p
+
+        init = gamma.parse_baseline_header(self.init)
+        # Initial values are ignored
+        assert init != exp_i
+        assert init != exp_p
+
+
+    def test_init_baseline_read(self):
+        """Test that the Initial baseline values are being read"""
+        exp_i = {'BASELINE_T': 0.6529765, 'BASELINE_C': -103.9065694,
+                 'BASELINE_N': 2.9253896, 'BASELINE_RATE_T': 0.0,
+                 'BASELINE_RATE_C': -0.0231786,
+                 'BASELINE_RATE_N': -0.0038703}
+
+        exp_p = {'BASELINE_T': 0.0, 'BASELINE_C': 0.0,
+                 'BASELINE_N': 0.0, 'BASELINE_RATE_T': 0.0,
+                 'BASELINE_RATE_C': 0.0, 'BASELINE_RATE_N': 0.0}
+
+        prec = gamma.parse_baseline_header(self.prec)
+        # Precise values are ignored
+        assert prec != exp_i
+        assert prec != exp_p
+
+        init = gamma.parse_baseline_header(self.init)
+        # Initial values are read
+        assert init == exp_i
+        assert init != exp_p
+

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -369,9 +369,10 @@ class TestGammaBaselineRead:
     """Tests the reading of initial and precise baselines"""
 
     def setup_method(self):
-        self.init = join(GAMMA_TEST_DIR, '20160114-20160126_base_init.par')
-        self.prec = join(GAMMA_TEST_DIR, '20160114-20160126_base.par')
-
+        init_path = join(GAMMA_TEST_DIR, '20160114-20160126_base_init.par')
+        self.init = gamma.parse_baseline_header(init_path)
+        prec_path = join(GAMMA_TEST_DIR, '20160114-20160126_base.par')
+        self.prec = gamma.parse_baseline_header(prec_path)
 
     def test_prec_baseline_read(self):
         """Test that the Precise baseline values are being read"""
@@ -385,15 +386,13 @@ class TestGammaBaselineRead:
                  'BASELINE_RATE_C': -0.0182215,
                  'BASELINE_RATE_N': -0.0065402}
 
-        prec = gamma.parse_baseline_header(self.prec)
         # Precise values are read
-        assert prec != exp_i
-        assert prec == exp_p
+        assert self.prec != exp_i
+        assert self.prec == exp_p
 
-        init = gamma.parse_baseline_header(self.init)
         # Initial values are ignored
-        assert init != exp_i
-        assert init != exp_p
+        assert self.init != exp_i
+        assert self.init != exp_p
 
 
     def test_init_baseline_read(self):
@@ -407,13 +406,11 @@ class TestGammaBaselineRead:
                  'BASELINE_N': 0.0, 'BASELINE_RATE_T': 0.0,
                  'BASELINE_RATE_C': 0.0, 'BASELINE_RATE_N': 0.0}
 
-        prec = gamma.parse_baseline_header(self.prec)
         # Precise values are ignored
-        assert prec != exp_i
-        assert prec != exp_p
+        assert self.prec != exp_i
+        assert self.prec != exp_p
 
-        init = gamma.parse_baseline_header(self.init)
         # Initial values are read
-        assert init == exp_i
-        assert init != exp_p
+        assert self.init == exp_i
+        assert self.init != exp_p
 


### PR DESCRIPTION
This PR adds support for reading and using the Initial baseline estimates from GAMMA `*base.par` files.

The Precise baseline estimate will be used if it is found (i.e. if one of the TCN components is non-zero), otherwise the Initial baseline estimates will be read.

This change is required to support interferograms where precise baseline estimation has been skipped (i.e. when the orbital state vectors are deemed adequate to solve for the orbital phase contribution. This is usually the case for Sentinel-1).