### PR TITLE
Replace dictionaries with buffers when merging loop closure calculations between processes [ci skip]

### DIFF
--- a/pyrate/core/phase_closure/sum_closure.py
+++ b/pyrate/core/phase_closure/sum_closure.py
@@ -107,6 +107,9 @@ def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: 
         log.info("Memory usage due to ifgs_breach_count_process {:2.4f}GB of data".format(total_gb))
         log.debug(f"shape of ifgs_breach_count_process is {ifgs_breach_count_process.shape}")
         log.debug(f"dtype of ifgs_breach_count_process is {ifgs_breach_count_process.dtype}")
+
+        total_gb = mpiops.comm.allreduce(closure_process.nbytes / 1e9, op=mpiops.MPI.SUM)
+        log.info("Memory usage due to closure_process {:2.4f}GB of data".format(total_gb))
         if mpiops.rank == 0:
             ifgs_breach_count = np.zeros(shape=(ifgs[0].phase_data.shape + (n_ifgs,)), dtype=np.uint16)
 

--- a/pyrate/core/phase_closure/sum_closure.py
+++ b/pyrate/core/phase_closure/sum_closure.py
@@ -26,7 +26,6 @@ from pyrate.core.shared import Ifg, join_dicts
 from pyrate.core.phase_closure.mst_closure import Edge, WeightedLoop
 from pyrate.core.logger import pyratelogger as log
 
-
 IndexedIfg = namedtuple('IndexedIfg', ['index', 'IfgPhase'])
 
 
@@ -63,7 +62,7 @@ def __create_ifg_edge_dict(ifg_files: List[str], params: dict) -> Dict[Edge, Ind
 
 
 def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: dict) -> \
-        Tuple[NDArray[(Any, Any, Any), Float32], NDArray[(Any, Any, Any), UInt16], NDArray[(Any, ), UInt16]]:
+        Tuple[NDArray[(Any, Any, Any), Float32], NDArray[(Any, Any, Any), UInt16], NDArray[(Any,), UInt16]]:
     """
     Compute the closure sum for each pixel in each loop, and count the number of times a pixel
     contributes to a failed closure loop (where the summed closure is above/below the 
@@ -73,14 +72,14 @@ def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: 
     :param params: params dict
     :return: Tuple of closure, ifgs_breach_count_process, num_occurrences_each_ifg
         closure: summed closure for each loop.
-        ifgs_breach_count_process: shape=(ifg.shape, n_ifgs) number of times a pixel in an ifg fails the closure
+        ifgs_breach_count: shape=(ifg.shape, n_ifgs) number of times a pixel in an ifg fails the closure
             check (i.e., has unwrapping error) in all loops under investigation.
         num_occurrences_each_ifg: frequency of ifg appearance in all loops.
     """
     edge_to_indexed_ifgs = __create_ifg_edge_dict(ifg_files, params)
     ifgs = [v.IfgPhase for v in edge_to_indexed_ifgs.values()]
     n_ifgs = len(ifgs)
-    closure = None
+    num_occurrences_each_ifg = _find_num_occurrences_each_ifg(loops, edge_to_indexed_ifgs, n_ifgs)
 
     if params[C.PARALLEL]:
         # rets = Parallel(n_jobs=params[cf.PROCESSES], verbose=joblib_log_level(cf.LOG_LEVEL))(
@@ -89,39 +88,24 @@ def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: 
         # )
         # for k, r in enumerate(rets):
         #     closure_dict[k], ifgs_breach_count_dict[k] = r
-        # TODO: enable multiprocessing - needs pickle error fix
+        # TODO: enable multiprocessing - needs pickle error workaround
+        closure = np.zeros(shape=(* ifgs[0].phase_data.shape, len(loops)), dtype=np.float32)
         ifgs_breach_count = np.zeros(shape=(ifgs[0].phase_data.shape + (n_ifgs,)), dtype=np.uint16)
-        closure = np.zeros((len(loops), *ifgs[0].phase_data.shape), dtype=np.float32)
         for k, weighted_loop in enumerate(loops):
-            closure[k,:,:], ifgs_breach_count_l = __compute_ifgs_breach_count(weighted_loop, edge_to_indexed_ifgs,
-                                                                               params)
+            closure[:, :, k], ifgs_breach_count_l = __compute_ifgs_breach_count(weighted_loop, edge_to_indexed_ifgs,
+                                                                                params)
             ifgs_breach_count += ifgs_breach_count_l
+        return closure, ifgs_breach_count, num_occurrences_each_ifg
     else:
-        process_loops = mpiops.array_split(loops)
+        closure_dict = {}
+        loops_with_index = list(enumerate(loops))
+        process_loops = mpiops.array_split(loops_with_index)
         ifgs_breach_count_process = np.zeros(shape=(ifgs[0].phase_data.shape + (n_ifgs,)), dtype=np.uint16)
-        closure_process = np.zeros((len(loops), *ifgs[0].phase_data.shape), dtype=np.float32)
-        for k, weighted_loop in enumerate(process_loops):
-            closure_process[k,:,:], ifgs_breach_count_l = __compute_ifgs_breach_count(weighted_loop, edge_to_indexed_ifgs,
+        for k, weighted_loop in process_loops:
+            closure_dict[k], ifgs_breach_count_l = __compute_ifgs_breach_count(weighted_loop, edge_to_indexed_ifgs,
                                                                                params)
             ifgs_breach_count_process += ifgs_breach_count_l  # process
-        if mpiops.rank == 0:
-            closure = np.zeros((len(loops), *ifgs[0].phase_data.shape), dtype=np.float32)
-        if mpiops.MPI_INSTALLED:
-            #this Gatherv setup depends on the behaviour of np.array_split
-            #and the default row-major order of numpy arrays.
-            counts = ([len(loops) // mpiops.size + 1] * (len(loops) % mpiops.size) +
-                      [len(loops) // mpiops.size] * (mpiops.size - (len(loops) % mpiops.size)))
-            displs = [0]
-            for i in range(1,mpiops.size):
-                displs.append(displs[-1] + counts[i-1])
-            ifgres = np.prod(ifgs[0].phase_data.shape)
-            counts = [c * ifgres for c in counts]
-            displs = [d * ifgres for d in displs]
-            mpiops.comm.Gatherv([closure_process, len(process_loops), mpiops.MPI.FLOAT],
-                                [closure, counts, displs, mpiops.MPI.FLOAT], root = 0)
-            #TODO use Gatherv instead of allocating extra zeros and using Reduce
-        else:
-            closure = closure_process #if MPI isn't installed there's only one process so this is fine
+        closure_dict = join_dicts(mpiops.comm.gather(closure_dict, root=0))
 
         total_gb = mpiops.comm.allreduce(ifgs_breach_count_process.nbytes / 1e9, op=mpiops.MPI.SUM)
         log.info("Memory usage due to ifgs_breach_count_process {:2.4f}GB of data".format(total_gb))
@@ -139,17 +123,16 @@ def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: 
 
         log.debug(f"successfully summed phase closure breach array")
 
-    num_occurrences_each_ifg = None
-    if mpiops.rank == 0:
-        closure = np.moveaxis(closure, 0, -1)
-        num_occurrences_each_ifg = _find_num_occurrences_each_ifg(loops, edge_to_indexed_ifgs, n_ifgs)
-
-    return closure, ifgs_breach_count, num_occurrences_each_ifg
+        closure, num_occurrences_each_ifg = None, None
+        if mpiops.rank == 0:
+            num_occurrences_each_ifg = _find_num_occurrences_each_ifg(loops, edge_to_indexed_ifgs, n_ifgs)
+            closure = np.dstack([v for k, v in sorted(closure_dict.items(), key=lambda x: x[0])])
+        return closure, ifgs_breach_count, num_occurrences_each_ifg
 
 
 def _find_num_occurrences_each_ifg(loops: List[WeightedLoop],
                                    edge_to_indexed_ifgs: Dict[Edge, IndexedIfg],
-                                   n_ifgs: int) -> NDArray[(Any, ), UInt16]:
+                                   n_ifgs: int) -> NDArray[(Any,), UInt16]:
     """find how many times each ifg appears in total in all loops"""
     num_occurrences_each_ifg = np.zeros(shape=n_ifgs, dtype=np.uint16)
     for weighted_loop in loops:

--- a/pyrate/core/phase_closure/sum_closure.py
+++ b/pyrate/core/phase_closure/sum_closure.py
@@ -113,7 +113,7 @@ def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: 
                       [len(loops) // mpiops.size] * (mpiops.size - (len(loops) % mpiops.size)))
             displs = [0]
             for i in range(1,mpiops.size):
-                displs.append(displs[-1] + counts[i])
+                displs.append(displs[-1] + counts[i-1])
             ifgres = np.prod(ifgs[0].phase_data.shape)
             counts = [c * ifgres for c in counts]
             displs = [d * ifgres for d in displs]

--- a/pyrate/core/phase_closure/sum_closure.py
+++ b/pyrate/core/phase_closure/sum_closure.py
@@ -104,12 +104,12 @@ def sum_phase_closures(ifg_files: List[str], loops: List[WeightedLoop], params: 
             ifgs_breach_count_process += ifgs_breach_count_l  # process
 
         total_gb = mpiops.comm.allreduce(ifgs_breach_count_process.nbytes / 1e9, op=mpiops.MPI.SUM)
-        log.info("Memory usage due to ifgs_breach_count_process {:2.4f}GB of data".format(total_gb))
+        log.debug(f"Memory usage to compute ifgs_breach_count_process was {total_gb} GB")
         log.debug(f"shape of ifgs_breach_count_process is {ifgs_breach_count_process.shape}")
         log.debug(f"dtype of ifgs_breach_count_process is {ifgs_breach_count_process.dtype}")
 
         total_gb = mpiops.comm.allreduce(closure_process.nbytes / 1e9, op=mpiops.MPI.SUM)
-        log.info("Memory usage due to closure_process {:2.4f}GB of data".format(total_gb))
+        log.debug(f"Memory usage to compute closure_process was {total_gb} GB")
         if mpiops.rank == 0:
             ifgs_breach_count = np.zeros(shape=(ifgs[0].phase_data.shape + (n_ifgs,)), dtype=np.uint16)
 

--- a/scripts/plot_ifgs.py
+++ b/scripts/plot_ifgs.py
@@ -98,7 +98,7 @@ def main():
         for p_r in range(plt_rows):
             for p_c in range(plt_cols):
                 ax = fig.add_subplot(plt_rows, plt_cols, fig_plots + 1)
-                ifg_num = plt_cols * p_r + p_c
+                ifg_num = plt_cols * p_r + p_c + ifgs_per_plot * i
                 file = ifgs[ifg_num]
                 log.info(f'Plotting {file}')
                 __plot_ifg(file, cmap, ax, num_ifgs,

--- a/tests/phase_closure/test_plot_closure.py
+++ b/tests/phase_closure/test_plot_closure.py
@@ -62,6 +62,6 @@ def test_plot_closure(mexico_cropa_params):
         else:
             correct.correct_steps[step](params)
 
-    closure_plot_file = Path(config.phase_closure_dir).joinpath(f'closure_loops_iteration_1.png')
+    closure_plot_file = Path(config.phase_closure_dir).joinpath(f'closure_loops_iteration_1_fig_0.png')
     assert closure_plot_file.exists()
     shutil.rmtree(params[C.OUT_DIR], ignore_errors=True)


### PR DESCRIPTION
Was having another issue with `sum_phase_closures` which was related to the numpy-array-in-a-dictionary design pattern we're using for inter-process communication - this simply doesn't work with big stacks of interferograms because if the limit on maximum size of a pickle, so I replaced it with a preallocated buffer and a call to `Gatherv`, along with the associated calculations of buffer sizes and stuff for each process.