### PR TITLE
Change method to drop ifgs with unwrapping errors in phase closure iterations

### DIFF
--- a/pyrate/core/phase_closure/closure_check.py
+++ b/pyrate/core/phase_closure/closure_check.py
@@ -95,7 +95,7 @@ def __drop_ifgs_exceeding_threshold(orig_ifg_files: List[str], ifgs_breach_count
         loop_count_of_this_ifg = num_occurences_each_ifg[i]
         if loop_count_of_this_ifg:  # if the ifg participated in at least one loop
             ifg_remove_threshold_breached = \
-                np.sum(ifgs_breach_count[:, :, i]) / loop_count_of_this_ifg / nrows / ncols > params[
+                np.sum(ifgs_breach_count[:, :, i] == loop_count_of_this_ifg) / (nrows * ncols) > params[
                     C.AVG_IFG_ERR_THR]
             if not (
                     # min loops count # check 1


### PR DESCRIPTION
This PR changes the method we use to drop interferograms from the next iteration of phase closure checking - currently, a misclosure in a pixel for *any* loop the ifg appears in counts towards the comparison with `avg_ifg_err_thr`. If we have a large stack with many loops, an unwrapping error in one ifg will result in misclosures for many other ifgs, so this method means we end up dropping a lot of good interferograms.

The PR uses a stricter criterion - how many pixels have misclosures for *all* loops the ifg appears in? In my experiments, this results in keeping a lot more good ifgs for large stacks, and as a bonus is consistent with the logic we use to mask unwrapping errors in the final output of the phase closure module.