### PR TITLE
Bugfix: Detect and ignore NaNs in per-pixel dem error calculation

### DIFF
--- a/tests/test_dem_error.py
+++ b/tests/test_dem_error.py
@@ -209,7 +209,7 @@ class TestDEMErrorResults:
         ref_phase_est_wrapper(self.params)
         dem_error_calc_wrapper(self.params)
         # dem_error.tif from this run (result)
-        dem_error_tif_res = join(self.params[C.OUT_DIR], 'dem_error.tif')
+        dem_error_tif_res = join(self.params[C.DEM_ERROR_DIR], 'dem_error.tif')
         dem = DEM(dem_error_tif_res)
         dem_error_res = dem.data
         # check equality


### PR DESCRIPTION
_This is a small PR for some additions to the `dem_error.py` file, we should create a new PR for some proper testing of the DEM error corrections._

**The per-pixel DEM error estimation loop would fail because the loop would contain NaNs from out of frame regions**
- added a for loop skip in dem error estimation for pixels with NaNs

**The baseline metadata in the IFG GeoTIFFs were not being updated because of the use of np.mean in the presence of NaNs**
- converted 2x np.mean() functions to np.nanmean()


_I also did some code tidying_