### PR TITLE
Add plotting script for correction files

### DIFF
--- a/utils/plot_correction_files.py
+++ b/utils/plot_correction_files.py
@@ -112,26 +112,25 @@ for i in range(first_ifg_num, last_ifg_num + 1):
     ifg_quant = np.nanquantile(ifg, [0.05, 0.95])
     climit = np.nanmax(np.abs(ifg_quant))
     
-    # subtract median
-    
+    # switch to subtract median or not
     if subtract_median == 1:
-        sub_med = 1
+        switch = 1
     else:
-        sub_med = 0
+        switch = 0
     
 
     fig, ax = plt.subplots(1,3, figsize=(6, 3))
      
     # IFG
-    s0 = ax[0].imshow(ifg-(np.nanmedian(ifg)*sub_med), cmap='bwr', clim=(-1*climit, climit))
+    s0 = ax[0].imshow(ifg-(np.nanmedian(ifg)*switch), cmap='bwr', clim=(-1*climit, climit))
     ax[0].set_axis_off()
 
     # CORRECTION FILE
-    s1 =ax[1].imshow(corr-(np.nanmedian(corr)*sub_med), cmap='bwr', clim=(-1*climit, climit))
+    s1 =ax[1].imshow(corr-(np.nanmedian(corr)*switch), cmap='bwr', clim=(-1*climit, climit))
     ax[1].set_axis_off()
 
     # IFG CORRECTED
-    s2 = ax[2].imshow(ifg_corr-(np.nanmedian(ifg_corr)*sub_med), cmap='bwr', clim=(-1*climit,climit))
+    s2 = ax[2].imshow(ifg_corr-(np.nanmedian(ifg_corr)*switch), cmap='bwr', clim=(-1*climit,climit))
     ax[2].set_axis_off()
 
     # Extra

--- a/utils/plot_correction_files.py
+++ b/utils/plot_correction_files.py
@@ -25,7 +25,7 @@ Command-line arguments:
 """
 
 # Arguments
-parser = argparse.ArgumentParser(description="Script to plot orbit correction files with uncorrected and corrected interferogram")
+parser = argparse.ArgumentParser(description="Script to plot correction files with uncorrected and corrected interferogram")
 parser.add_argument("IFG_DIR", type=str, help="full path to uncorrected interferograms in PyRate")
 parser.add_argument("CORRECTION_FILE_DIR", type=str, help="full path to correction files in PyRate")
 parser.add_argument("CORRECTED_IFG_DIR", type=str, help="full path to corrected interferograms in PyRate")

--- a/utils/plot_correction_files.py
+++ b/utils/plot_correction_files.py
@@ -1,0 +1,124 @@
+import numpy as np
+from matplotlib import pyplot as plt
+import glob
+import re
+import math
+import rasterio as rio
+import argparse
+import os
+
+"""
+This script plots the original interferogram, the corresponding correction file, 
+and the resulting corrected interferogram from a PyRate directory with already,
+processed data. directories are given as user arguments to the script, and the
+number of plots is determined by a number range given by user. 
+
+Usage: python3 plot_correction_files.py <IFG_DIR> <CORRECTION_DIR> <CORRECTED_DIR> <SAVE_DIR> <FIRST_IFG> <LAST_IFG>
+
+Command-line arguments:
+           IFG_DIR       - full path to uncorrected interferograms in PyRate.
+    CORRECTION_DIR       - full path to correction files in PyRate.
+     CORRECTED_DIR       - full path to corrected interferograms in PyRate.
+          SAVE_DIR       - full path to directory where images will be saved (needs to exist).
+         FIRST_IFG       - first IFG in range of IFGs to plot (e.g. 1 to start plotting at 1st IFG in directory).
+          LAST_IFG       - last IFG in range of IFGs to plot (e.g. 37 will plot up until the 37th IFG in directory).
+"""
+
+# Arguments
+parser = argparse.ArgumentParser(description="Script to plot orbit correction files with uncorrected and corrected interferogram")
+parser.add_argument("IFG_DIR", type=str, help="full path to uncorrected interferograms in PyRate")
+parser.add_argument("CORRECTION_FILE_DIR", type=str, help="full path to correction files in PyRate")
+parser.add_argument("CORRECTED_IFG_DIR", type=str, help="full path to corrected interferograms in PyRate")
+parser.add_argument("SAVE_DIR", type=str, help="full path to directory where images will be saved")
+parser.add_argument("FIRST_IFG", type=int, help="first IFG in range of IFGs to plot (e.g. 1 to start plotting at first IFG in directory)")
+parser.add_argument("LAST_IFG", type=int, help="last IFG in range of IFGs to plot (e.g. 37 will plot up until the 37th IFG in directory)")
+args = parser.parse_args()
+
+
+
+# Directories and variable from user agruments
+ifg_dir = os.path.abspath(args.IFG_DIR)
+corr_dir = os.path.abspath(args.CORRECTION_FILE_DIR)
+tempml_dir = os.path.abspath(args.CORRECTED_IFG_DIR)
+save_dir = os.path.abspath(args.SAVE_DIR)
+
+first_ifg_num = args.FIRST_IFG - 1
+last_ifg_num = args.LAST_IFG - 1
+
+
+# Create Lists
+ifg_list = []
+for file in glob.glob(f'{ifg_dir}/*ifg.tif'):
+    ifg_list.append(file)
+
+corr_list = []
+for file in glob.glob(f'{corr_dir}/*.npy'):
+    corr_list.append(file)
+
+tempml_list = []
+for file in glob.glob(f'{tempml_dir}/*ifg.tif'):
+    tempml_list.append(file)
+
+# Sort
+ifg_list.sort()
+corr_list.sort()
+tempml_list.sort()
+
+for i in range(first_ifg_num, last_ifg_num + 1):    
+    
+    # Read data
+    with rio.open(ifg_list[i]) as src:
+        ifg = src.read(1)
+        ifg[ifg==0.0] = np.nan
+        mask = np.isnan(ifg)
+    
+        # convert to mm 
+        ifg = ifg * 1000 * (0.0562356424 / (4 * math.pi))
+    
+    corr =  np.load(corr_list[i])
+    corr[mask] = np.nan
+    
+
+    with rio.open(tempml_list[i]) as src:
+        ifg_corr = src.read(1)
+    
+    # Identify Date Pair
+    date_pair_list = re.findall(r'\d{8}-\d{8}', ifg_list[i])
+    date_pair_string = date_pair_list[0]
+    
+    print(f'\nPlotting for {date_pair_string}...\n')
+    
+    # Plot
+    climit = 100
+    fig, ax = plt.subplots(1,3, figsize=(6, 3))
+     
+    # IFG
+    s0 = ax[0].imshow(ifg-np.nanmedian(ifg), cmap='bwr', clim=(-1*climit, climit))
+    ax[0].set_axis_off()
+
+    # CORRECTION FILE
+    s1 =ax[1].imshow(corr-np.nanmedian(corr), cmap='bwr', clim=(-1*climit, climit))
+    ax[1].set_axis_off()
+
+    # IFG CORRECTED
+    s2 = ax[2].imshow(ifg_corr-np.nanmedian(ifg_corr), cmap='bwr', clim=(-1*climit,climit))
+    ax[2].set_axis_off()
+
+    # Extra
+    fig.colorbar(s0, ax=ax[0], location='bottom', label='mm')
+    fig.colorbar(s1, ax=ax[1], location='bottom', label='mm')
+    fig.colorbar(s2, ax=ax[2], location='bottom', label='mm')
+
+    fig.set_facecolor('grey')
+    
+    fig.tight_layout()
+
+    # Title
+    ax[1].set_title(f'{date_pair_string}', fontsize=10, fontweight='bold')
+
+    plt.savefig(f'{save_dir}/{date_pair_string}.png', dpi=300)
+    
+    plt.close()
+
+    i = i + 1
+

--- a/utils/plot_correction_files.py
+++ b/utils/plot_correction_files.py
@@ -83,10 +83,26 @@ for i in range(first_ifg_num, last_ifg_num + 1):
         ifg_corr = src.read(1)
     
     # Identify Date Pair
-    date_pair_list = re.findall(r'\d{8}-\d{8}', ifg_list[i])
-    date_pair_string = date_pair_list[0]
+    date_pair_list_ifg = re.findall(r'\d{8}-\d{8}', ifg_list[i])
+    date_pair_string_ifg = date_pair_list_ifg[0]
+
+    date_pair_list_corr = re.findall(r'\d{8}-\d{8}', corr_list[i])
+    date_pair_string_corr = date_pair_list_corr[0]
+
+    date_pair_list_ifgcorr = re.findall(r'\d{8}-\d{8}', tempml_list[i])
+    date_pair_string_ifgcorr = date_pair_list_ifgcorr[0]
+
+    # Check the Date-pairs are the same in case of mismatched files saved into the directories
+    if date_pair_string_ifg == date_pair_string_corr and date_pair_string_ifg == date_pair_string_ifgcorr:
+       
+         print(f'\nPlotting for {date_pair_string_ifg}...\n')
+        pass
+
+    else:
+
+        print(f'\nERROR: Interferogram datepair mismatch at {date_pair_string_ifg}, check that directories have the same interferograms.\n')
+        break
     
-    print(f'\nPlotting for {date_pair_string}...\n')
     
     # Plot
     climit = 100
@@ -114,9 +130,9 @@ for i in range(first_ifg_num, last_ifg_num + 1):
     fig.tight_layout()
 
     # Title
-    ax[1].set_title(f'{date_pair_string}', fontsize=10, fontweight='bold')
+    ax[1].set_title(f'{date_pair_string_ifg}', fontsize=10, fontweight='bold')
 
-    plt.savefig(f'{save_dir}/{date_pair_string}.png', dpi=300)
+    plt.savefig(f'{save_dir}/{date_pair_string_ifg}.png', dpi=300)
     
     plt.close()
 

--- a/utils/plot_correction_files.py
+++ b/utils/plot_correction_files.py
@@ -22,6 +22,7 @@ Command-line arguments:
           SAVE_DIR       - full path to directory where images will be saved (needs to exist).
          FIRST_IFG       - first IFG in range of IFGs to plot (e.g. 1 to start plotting at 1st IFG in directory).
           LAST_IFG       - last IFG in range of IFGs to plot (e.g. 37 will plot up until the 37th IFG in directory).
+         NORMALISE       - Switch to subtract median to from figures (0=YES, 1=No, default is 0). 
 """
 
 # Arguments
@@ -32,6 +33,7 @@ parser.add_argument("CORRECTED_IFG_DIR", type=str, help="full path to corrected 
 parser.add_argument("SAVE_DIR", type=str, help="full path to directory where images will be saved")
 parser.add_argument("FIRST_IFG", type=int, help="first IFG in range of IFGs to plot (e.g. 1 to start plotting at first IFG in directory)")
 parser.add_argument("LAST_IFG", type=int, help="last IFG in range of IFGs to plot (e.g. 37 will plot up until the 37th IFG in directory)")
+parser.add_argument("-sm", "--subtract_median", type=int, default=1, help="Switch to subtract median to from figures (1=YES, 0=No, default is 1)")
 args = parser.parse_args()
 
 
@@ -44,6 +46,8 @@ save_dir = os.path.abspath(args.SAVE_DIR)
 
 first_ifg_num = args.FIRST_IFG - 1
 last_ifg_num = args.LAST_IFG - 1
+
+subtract_median = args.subtract_median
 
 
 # Create Lists
@@ -95,7 +99,7 @@ for i in range(first_ifg_num, last_ifg_num + 1):
     # Check the Date-pairs are the same in case of mismatched files saved into the directories
     if date_pair_string_ifg == date_pair_string_corr and date_pair_string_ifg == date_pair_string_ifgcorr:
        
-         print(f'\nPlotting for {date_pair_string_ifg}...\n')
+        print(f'\nPlotting for {date_pair_string_ifg}...\n')
         pass
 
     else:
@@ -104,20 +108,30 @@ for i in range(first_ifg_num, last_ifg_num + 1):
         break
     
     
-    # Plot
-    climit = 100
+    # PLOTTING
+    ifg_quant = np.nanquantile(ifg, [0.05, 0.95])
+    climit = np.nanmax(np.abs(ifg_quant))
+    
+    # subtract median
+    
+    if subtract_median == 1:
+        sub_med = 1
+    else:
+        sub_med = 0
+    
+
     fig, ax = plt.subplots(1,3, figsize=(6, 3))
      
     # IFG
-    s0 = ax[0].imshow(ifg-np.nanmedian(ifg), cmap='bwr', clim=(-1*climit, climit))
+    s0 = ax[0].imshow(ifg-(np.nanmedian(ifg)*sub_med), cmap='bwr', clim=(-1*climit, climit))
     ax[0].set_axis_off()
 
     # CORRECTION FILE
-    s1 =ax[1].imshow(corr-np.nanmedian(corr), cmap='bwr', clim=(-1*climit, climit))
+    s1 =ax[1].imshow(corr-(np.nanmedian(corr)*sub_med), cmap='bwr', clim=(-1*climit, climit))
     ax[1].set_axis_off()
 
     # IFG CORRECTED
-    s2 = ax[2].imshow(ifg_corr-np.nanmedian(ifg_corr), cmap='bwr', clim=(-1*climit,climit))
+    s2 = ax[2].imshow(ifg_corr-(np.nanmedian(ifg_corr)*sub_med), cmap='bwr', clim=(-1*climit,climit))
     ax[2].set_axis_off()
 
     # Extra


### PR DESCRIPTION
This script is designed to plot the correction files (NumPy), against the original interferogram and the corrected interferogram (GeoTIFFs) to aid user's interpretation of corrections and help debugging with PyRate. 

Here is an example where from left to right is original IFG (`interferogram_dir/`), correction applied (`orbit_error_dir/`), and resulting corrected IFG (`temp_mlooked_dir/`):

![image](https://user-images.githubusercontent.com/52764764/124406090-adb97980-dd83-11eb-9c00-9b2aa36bd430.png)



**Help Output**

![image](https://user-images.githubusercontent.com/52764764/124406573-135a3580-dd85-11eb-986f-4ba52a7c1838.png)




**Example Usage:**

`python3 ~/PyRate/utils/plot_correction_files.py ./interferogram_dir ./orbit_error_dir ./temp_mlooked_dir ./plot_save_dir 1 10`

_the last two arguments will indicate that it will plot from the 1st to the 10th IFG (10 separate PNGs), this can be changed to any range within the maximum number of IFGs in user PyRate directory. Using `1 1 ` will plot the 1st only_




**Notes**

- This script is designed to be generic and as simple as possible, so it is easy for any given user to change it on the fly in there own local repository (rather than a script that deals with every possible combination of processing). 
- The script is also naïve, in that it relies on the user to decide how valid the comparison is, depending on user's own processing (which corrections were applied etc.). 
- I have only tested this script on the Orbit and APS corrections, it theoretically should work on the DEM error correction too but I have not tested it. 
- Currently, the files we save out as APS "correction" files, don't seem to contain the full correction, work will be done to investigate this. 
- Users can plot a single IFG or the full time series based on the last two arguments (but users need to have awareness of how many IFGs are in their directory).
- If plotting full time series, consider running as a QSUB job (if on NCI), otherwise plotting subsets will not take up too much memory. 