### PR TITLE
Change so reference pixel is validated in function rather than callin…

### DIFF
--- a/pyrate/core/refpixel.py
+++ b/pyrate/core/refpixel.py
@@ -20,6 +20,7 @@ of the interferometric reference pixel
 import os
 from os.path import join
 from typing import Tuple
+from osgeo import gdal 
 
 from itertools import product
 
@@ -393,13 +394,21 @@ def __validate_supplied_lat_lon(params: dict) -> None:
     lon, lat = params[C.REFX], params[C.REFY]
     if lon == -1 or lat == -1:
         return
-    xmin, ymin, xmax, ymax = prepifg_helper.get_analysis_extent(
-        crop_opt=params[C.IFG_CROP_OPT],
-        rasters=[prepifg_helper.dem_or_ifg(p.sampled_path) for p in params[C.INTERFEROGRAM_FILES]],
-        xlooks=params[C.IFG_LKSX], ylooks=params[C.IFG_LKSY],
-        user_exts=(params[C.IFG_XFIRST], params[C.IFG_YFIRST], params[
-            C.IFG_XLAST], params[C.IFG_YLAST])
-    )
+
+    # Get extent of first IFG
+    src = gdal.Open(params[C.INTERFEROGRAM_FILES][0].sampled_path, gdal.GA_ReadOnly)
+    x_upleft, x_post, x_skew, y_upleft, y_skew, y_post  = src.GetGeoTransform()
+    
+    # Assign coordinates
+    xmin = x_upleft
+    ymax = y_upleft
+    xmax = x_upleft + (src.RasterXSize * x_post)
+    ymin = y_upleft + (src.RasterYSize * y_post)
+    
+    # Close IFG file
+    src = None
+
+    # Check coordinates
     msg = "Supplied {} value is outside the bounds of the interferogram data"
     lat_lon_txt = ''
     if (lon < xmin) or (lon > xmax):


### PR DESCRIPTION
This pull request contains a simple change in the way PyRate validates the custom (user defined) reference pixel location.

_Caveat: There was no test originally, so this issue was not picked up. I have also not created a test yet. I will aim to do that either before or after this gets merged._

**The Problem**
PyRate gives configuration options for the user to determine where the reference pixel will be `refx` and `refy` in longitude and latitude. There is also the option to crop the dataset with user defined coordinates so that PyRate only processes a smaller extent with `ifgcropopt:    3`. It is common for a user to use both of these options. The reference pixel selection is done during the _correct_ step, whilst the cropping is conducted prior, in the _prepifg_ step. 

- PyRate has a function inside `refpix.py` called `__validate_supplied_lat_lon()`. It is designed to confirm that the user supplied coordinates for the reference pixel are within the interferogram extent. 
- To obtain the spatial extent, the above function calls another function `get_analysis_extent()` which sits inside of `prepifg_helper.py`. 
- This sets off a sequence of other unrelated checks because this function was designed to operate during the _prepifg_ step. One of these functions is to validate that user supplied cropping coordinates are within the original interferogram extent. But by this stage of the processing (correct step), the interferogram has already been cropped. 
- So the comparison is comparing user supplied cropping extents which are to 3 decimal places to the newly cropped interferogram datasets which are to 7 decimal places. 

It results in this error:

```
Traceback (most recent call last):
  File "/home/547/ad6200/PyRateVenv/bin/pyrate", line 11, in <module>
    load_entry_point('Py-Rate==0.6.0', 'console_scripts', 'pyrate')()
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/main.py", line 116, in main
    correct.main(config)
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/correct.py", line 142, in main
    return correct_ifgs(config)
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/correct.py", line 226, in correct_ifgs
    params[C.REFX_FOUND], params[C.REFY_FOUND] = ref_pixel_calc_wrapper(params)
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/core/refpixel.py", line 423, in ref_pixel_calc_wrapper
    __validate_supplied_lat_lon(params)
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/core/refpixel.py", line 401, in __validate_supplied_lat_lon
    C.IFG_XLAST], params[C.IFG_YLAST])
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/core/prepifg_helper.py", line 81, in get_analysis_extent
    return _get_extents(rasters, crop_opt, user_exts)
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/core/prepifg_helper.py", line 146, in _get_extents
    extents = _custom_bounds(ifgs, *user_exts)
  File "/home/547/ad6200/PyRateVenv/lib/python3.7/site-packages/pyrate/core/prepifg_helper.py", line 332, in _custom_bounds
    raise PreprocessError(msg)
pyrate.core.prepifg_helper.PreprocessError: Cropped image bounds are outside the original image bounds
```


**Solution**
As the above user supplied cropping coordinates check is not relevant during this step, I have removed the call to the `get_analysis_extent()` from the `prepifg_helper.py` and implemented a validation of the user supplied reference pixel by getting dataset extents independently from within the `__validate_supplied_lat_lon()` function itself.


**In summary**

Old Code:
https://github.com/GeoscienceAustralia/PyRate/blob/d7222c27d98aa4339a5271713a9c3155f9826736/pyrate/core/refpixel.py#L389-L410

New Code:
https://github.com/GeoscienceAustralia/PyRate/blob/4aae0b95bc56aca9d7193045307d2f670eceef9b/pyrate/core/refpixel.py#L390-L419

