### PR TITLE
Fix wrong sign in Y-intercept output file

### DIFF
--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -279,7 +279,7 @@ out_type_md_dict = {
 }
 
 error_out_types = {'linear_error', 'stack_error'}
-los_projection_out_types = {'tsincr', 'tscuml', 'linear_rate', 'stack_rate'}
+los_projection_out_types = {'tsincr', 'tscuml', 'linear_rate', 'linear_intercept', 'stack_rate'}
 los_projection_divisors = {
     ifc.LINE_OF_SIGHT: lambda data: 1,
     ifc.PSEUDO_VERTICAL: lambda data: np.cos(data),

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -119,8 +119,8 @@ class TestLOSConversion:
         los_proj_dir = all_dirs[ifc.LINE_OF_SIGHT]
         pseudo_ver = all_dirs[ifc.PSEUDO_VERTICAL]
         pseudo_hor = all_dirs[ifc.PSEUDO_HORIZONTAL]
-        num_files = 24 if params[C.PHASE_CLOSURE] else 26  # phase closure removes 1 interferogram
-        assert len(list(los_proj_dir.glob('*.tif'))) == num_files  # 12 tsincr, 12 tscuml + 1 stack rate + 1 linear rate
+        num_files = 25 if params[C.PHASE_CLOSURE] else 27  # phase closure removes 1 interferogram
+        assert len(list(los_proj_dir.glob('*.tif'))) == num_files  # 12 tsincr, 12 tscuml + 1 stack rate + 1 linear rate + 1 linear intercept
         signal_polarity_reversed_pseudo_hor = all_dirs[C.SIGNAL_POLARITY]
 
         for tif in los_proj_dir.glob('*.tif'):


### PR DESCRIPTION
This is a small PR with a very small code change. It relates to the output files in the `velocity_dir` where the Y-intercept file `linear_intercept.tif` is not sign-reversed like the other output files when the user set config parameter `signal_polarity: -1` is set. 

See this issue for more details: https://github.com/GeoscienceAustralia/PyRate/issues/353

**Description**
- A part of the PyRate output is a GeoTIFF of Y-Intercept values (`linear_intercept.tif`) for each pixel to accompany the GeoTIFF containing rate values estimated by PyRate from the per pixel cumulative time series. 
- There is an option in PyRate configuration file to reverse the sign of the line-of-sight values so that the time series makes physical sense `signal_polarity: -1`. 
- The sign change occurs in the _merge_ step and seems to operate only on the time series data and the rate output but **not** on the Y-Intercept output. 
- This means that when users are plotting PyRate results, there is a mismatch between the Rate and Y-Intercept.

**Recommended Review Strategy**
This is a very small PR, so just looking at the code change might suffice if you wish. Otherwise, you could run some tests by turning `signal_polarity` to `1` and `-1` respectively and compare to make sure that `linear_intercept.tif` has opposite signs in each case. 


**Expected Behavior**
When the signal_polarity: -1 option applied, the change of sign should work consistently across all outputs.


**Solution**
I have simply added the `linear_intercept` array to the list of files that the sign change occurs on. 


**In Summary**

Old Code:
https://github.com/GeoscienceAustralia/PyRate/blob/8203989e7d9b675491e79610cff04728d8dc3973/pyrate/merge.py#L282

New Code:
https://github.com/GeoscienceAustralia/PyRate/blob/2a2451858561e2dc17c0d318cd588ed9d3b22b9b/pyrate/merge.py#L282


**Additional Notes**
- Currently the LOS projection and the signal polarity change all occur in the same equation for all conditional options. 
- Ideally I would restructure the code in this section to simplify the LOS projections and signal polarity conversion by separating these so it is easier to track what is happening (this is out of scope for this quick-fix PR).  
- See below on line 325 where currently the LOS projection and sign conversion happen:

https://github.com/GeoscienceAustralia/PyRate/blob/8203989e7d9b675491e79610cff04728d8dc3973/pyrate/merge.py#L290-L328

