### PR TITLE
Add metadata to output files

### DIFF
--- a/pyrate/core/prepifg_helper.py
+++ b/pyrate/core/prepifg_helper.py
@@ -313,7 +313,7 @@ def _custom_bounds(ifgs, xw, ytop, xe, ybot):
 
     if xe < xw:
         raise PreprocessError('ERROR Custom crop bounds: '
-                              'ifgxfirst must be greater than ifgxlast')
+                              'ifgxfirst must be less than ifgxlast')
 
     for par, crop, orig, step in zip(['x_first', 'x_last', 'y_first', 'y_last'],
                                      [xw, xe, ytop, ybot],

--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -114,8 +114,6 @@ def _merge_linrate(params: dict) -> None:
     # read and assemble tile outputs
     out_types = ['linear_' + x for x in ['rate', 'rsquared', 'error', 'intercept', 'samples']]
     process_out_types = mpiops.array_split(out_types)
-
-
     
     for p_out_type in process_out_types:
         out = assemble_tiles(shape, params[C.TMPDIR], tiles, out_type=p_out_type)

--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -123,7 +123,7 @@ def _merge_linrate(params: dict) -> None:
  
     ## Add metadata to output files
 
-    # Get Reference pixel coordinates from first IFG metadata in corrected IFG directory
+    # Get reference pixel coordinates from first IFG metadata in corrected IFG directory
     src = gdal.Open(params[C.INTERFEROGRAM_FILES][0].tmp_sampled_path, gdal.GA_ReadOnly)
     metadata = src.GetMetadata()
     lon = metadata["REF_PIX_LON"]
@@ -140,7 +140,7 @@ def _merge_linrate(params: dict) -> None:
     else:        
         azimuth_median = "NOT COMPUTED"
 
-    # Add reference pixel coordinates to output GeoTIFF metadata in velocity directory
+    # Add metadata details to final output GeoTIFFs in velocity directory
     for file in glob.glob(f'{params[C.VELOCITY_DIR]}/*tif'):
 
         src = gdal.Open(file)

--- a/pyrate/merge.py
+++ b/pyrate/merge.py
@@ -24,6 +24,8 @@ from osgeo import gdal
 import subprocess
 from pathlib import Path
 from typing import Optional, Tuple
+import glob
+import math
 
 import pyrate.constants as C
 from pyrate.core import shared, stack, ifgconstants as ifc, mpiops
@@ -112,11 +114,41 @@ def _merge_linrate(params: dict) -> None:
     # read and assemble tile outputs
     out_types = ['linear_' + x for x in ['rate', 'rsquared', 'error', 'intercept', 'samples']]
     process_out_types = mpiops.array_split(out_types)
+
+
+    
     for p_out_type in process_out_types:
         out = assemble_tiles(shape, params[C.TMPDIR], tiles, out_type=p_out_type)
         __save_merged_files(ifgs_dict, params, out, p_out_type, savenpy=params["savenpy"])
     mpiops.comm.barrier()
 
+ 
+    ## Add metadata to output files
+
+    # Get Reference pixel coordinates from first IFG metadata in corrected IFG directory
+    src = gdal.Open(params[C.INTERFEROGRAM_FILES][0].tmp_sampled_path, gdal.GA_ReadOnly)
+    metadata = src.GetMetadata()
+    lon = metadata["REF_PIX_LON"]
+    lat = metadata["REF_PIX_LAT"] 
+    src = None
+
+    # Get median azimuth direction of LOS vector from azimuth_angle.tif if exists
+    if isfile(f'{params[C.GEOMETRY_DIR]}/azimuth_angle.tif'):
+        src = gdal.Open(f'{params[C.GEOMETRY_DIR]}/azimuth_angle.tif')
+        data = src.ReadAsArray()
+        azimuth_median = np.nanmedian(data)*(180/math.pi)
+        src = None
+
+    else:        
+        azimuth_median = "NOT COMPUTED"
+
+    # Add reference pixel coordinates to output GeoTIFF metadata in velocity directory
+    for file in glob.glob(f'{params[C.VELOCITY_DIR]}/*tif'):
+
+        src = gdal.Open(file)
+        src.SetMetadata({"REF_PIX_LON": str(lon), "REF_PIX_LAT": str(lat), "MEDIAN_AZIMUTH": str(azimuth_median)})
+        src = None
+    
 
 def _merge_timeseries(params: dict, tstype: str) -> None:
     """


### PR DESCRIPTION
This is a small PR that adds some simple metadata to the output files in the velocity directory. 

**Specifically**
Here are the three changes and their associated GitHub issues:

1. Add latitude and longitude coordinates of reference pixel to the output GeoTIFFs in `velocity_dir` (https://github.com/GeoscienceAustralia/PyRate/issues/358).

2. Add median azimuth of the LOS vector to the output GeoTIFFS in `velocity_dir` (https://github.com/GeoscienceAustralia/PyRate/issues/359).

3. Just a small correction to an error message which was stating the wrong condition (https://github.com/GeoscienceAustralia/PyRate/issues/362)

**Recommended Review Strategy**
In addition to checking that none of these break your processing workflow, here are some things to check regarding  the above points. 

1. Confirm that the reference pixel coordinates are in the output GeoTIFF metadata at the end of processing.
2. At the end of processing, check that the median azimuth is in the output GeoTIFF metadata, or that `NOT COMPUTED` is there in the case that the geometry files are not created. 
3. Just read over the code and confirm if the conditional logic is correct. 

