### PR TITLE
Only run CI on master and develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,11 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'develop'
   push:
     branches:
-      - '**'
+      - 'master'
+      - 'develop'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     if: ${{ ! (contains(github.event.head_commit.message, 'ci skip') || contains(github.event.head_commit.message, 'skip ci'))}}
     runs-on: ubuntu-18.04
-    name: Python ${{ matrix.python }}
+    name: Python ${{ matrix.python-version }}, GDAL ${{ matrix.GDALVERSION }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
The current `build.yml` runs on pushes to all branches, including the `gh-pages` branch which only contains the docs and no actual code, and will therefore always fail CI. It makes more sense to run it only on the "main" branches (`master` and `develop`), especially given the resources consumed by the CI runs.